### PR TITLE
effectActivationFlowの改善

### DIFF
--- a/src/game/progress/effect-activation-flow/activate-effect-or-not.ts
+++ b/src/game/progress/effect-activation-flow/activate-effect-or-not.ts
@@ -1,0 +1,26 @@
+import { burst } from "../../../effect/burst";
+import { pilotSkill } from "../../../effect/pilot-skill";
+import { GameState } from "../../../state/game-state";
+import { PlayerCommand } from "../../command/player-command";
+
+/**
+ * コマンドに応じて 効果発動 or 何もしない
+ * 何もしない場合はnullを返す
+ * @param state 最新のゲームステート
+ * @param command コマンド
+ * @returns 更新結果
+ */
+export function activateEffectOrNot(
+  state: GameState,
+  command: PlayerCommand,
+): GameState | null {
+  if (command.command.type === "BURST_COMMAND") {
+    return burst(state, command.playerId);
+  }
+
+  if (command.command.type === "PILOT_SKILL_COMMAND") {
+    return pilotSkill(state, command.playerId);
+  }
+
+  return null;
+}

--- a/src/game/progress/effect-activation-flow/index.ts
+++ b/src/game/progress/effect-activation-flow/index.ts
@@ -1,9 +1,9 @@
-import { burst } from "../../effect/burst";
-import { inputCommand } from "../../effect/input-command";
-import { pilotSkill } from "../../effect/pilot-skill";
-import type { GameState } from "../../state/game-state";
-import type { PlayerCommand } from "../command/player-command";
-import { startGameFlow } from "../game-flow";
+import { burst } from "../../../effect/burst";
+import { inputCommand } from "../../../effect/input-command";
+import { pilotSkill } from "../../../effect/pilot-skill";
+import type { GameState } from "../../../state/game-state";
+import type { PlayerCommand } from "../../command/player-command";
+import { startGameFlow } from "../../game-flow";
 
 /**
  * 効果発動フローを行うか否かを判定する

--- a/src/game/progress/effect-activation-flow/index.ts
+++ b/src/game/progress/effect-activation-flow/index.ts
@@ -1,45 +1,8 @@
-import { burst } from "../../../effect/burst";
 import { inputCommand } from "../../../effect/input-command";
-import { pilotSkill } from "../../../effect/pilot-skill";
-import type { GameState } from "../../../state/game-state";
-import type { PlayerCommand } from "../../command/player-command";
+import { GameState } from "../../../state/game-state";
+import { PlayerCommand } from "../../command/player-command";
 import { startGameFlow } from "../../game-flow";
-
-/**
- * 効果発動フローを行うか否かを判定する
- * @param commands プレイヤーが選択したコマンド
- * @returns 判定結果、trueでバーストフェイズを行う
- */
-export function isEffectActivationFlow(
-  commands: [PlayerCommand, PlayerCommand],
-): boolean {
-  const types = commands.map((v) => v.command.type);
-  return (
-    types.includes("BURST_COMMAND") || types.includes("PILOT_SKILL_COMMAND")
-  );
-}
-
-/**
- * コマンドに応じて 効果発動 or 何もしない
- * 何もしない場合はnullを返す
- * @param state 最新のゲームステート
- * @param command コマンド
- * @returns 更新結果
- */
-export function activationOrNot(
-  state: GameState,
-  command: PlayerCommand,
-): GameState | null {
-  if (command.command.type === "BURST_COMMAND") {
-    return burst(state, command.playerId);
-  }
-
-  if (command.command.type === "PILOT_SKILL_COMMAND") {
-    return pilotSkill(state, command.playerId);
-  }
-
-  return null;
-}
+import { activateEffectOrNot } from "./activate-effect-or-not";
 
 /**
  * 効果発動フロー
@@ -64,11 +27,11 @@ export function effectActivationFlow(
 
   return startGameFlow(lastState, [
     (state) => {
-      const done = activationOrNot(state, attackerCommand);
+      const done = activateEffectOrNot(state, attackerCommand);
       return done ? [done] : [];
     },
     (state) => {
-      const done = activationOrNot(state, defenderCommand);
+      const done = activateEffectOrNot(state, defenderCommand);
       return done ? [done] : [];
     },
     (state) => [

--- a/src/game/progress/effect-activation-flow/is-effect-activation-flow.ts
+++ b/src/game/progress/effect-activation-flow/is-effect-activation-flow.ts
@@ -1,0 +1,15 @@
+import { PlayerCommand } from "../../command/player-command";
+
+/**
+ * 効果発動フローを行うか否かを判定する
+ * @param commands プレイヤーが選択したコマンド
+ * @returns 判定結果、trueでバーストフェイズを行う
+ */
+export function isEffectActivationFlow(
+  commands: [PlayerCommand, PlayerCommand],
+): boolean {
+  const types = commands.map((v) => v.command.type);
+  return (
+    types.includes("BURST_COMMAND") || types.includes("PILOT_SKILL_COMMAND")
+  );
+}

--- a/src/game/progress/index.ts
+++ b/src/game/progress/index.ts
@@ -2,10 +2,8 @@ import type { BatteryCommand } from "../../command/battery";
 import type { GameState } from "../../state/game-state";
 import type { PlayerCommand } from "../command/player-command";
 import { battleFlow } from "./battle-flow";
-import {
-  effectActivationFlow,
-  isEffectActivationFlow,
-} from "./effect-activation-flow";
+import { effectActivationFlow } from "./effect-activation-flow";
+import { isEffectActivationFlow } from "./effect-activation-flow/is-effect-activation-flow";
 
 /**
  * ゲームを進める

--- a/test/game/progress/activate-effect-or-not.test.ts
+++ b/test/game/progress/activate-effect-or-not.test.ts
@@ -1,25 +1,35 @@
-import type {
+import {
   BatteryCommand,
   BurstCommand,
+  EMPTY_GAME_STATE,
+  EMPTY_PLAYER_STATE,
   GameState,
+  PilotSkillCommand,
   PlayerCommand,
   PlayerState,
 } from "../../../src";
-import type { PilotSkillCommand } from "../../../src/command/pilot-skill";
-import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
-import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
-import { activationOrNot } from "../../../src/game/progress/effect-activation-flow";
+import { activateEffectOrNot } from "../../../src/game/progress/effect-activation-flow/activate-effect-or-not";
+
+/** バーストコマンド */
 const BURST_COMMAND: BurstCommand = {
   type: "BURST_COMMAND",
 };
+
+/** バッテリーコマンド */
 const BATTERY_COMMAND: BatteryCommand = {
   type: "BATTERY_COMMAND",
   battery: 2,
 };
+
+/** パイロットスキルコマンド */
 const PILOT_SKILL_COMMAND: PilotSkillCommand = {
   type: "PILOT_SKILL_COMMAND",
 };
+
+/** バースト発動プレイヤー */
 const TEST_PLAYER: PlayerState = { ...EMPTY_PLAYER_STATE, playerId: "test" };
+
+/** それ以外のプレイヤー */
 const OTHER_PLAYER: PlayerState = { ...EMPTY_PLAYER_STATE, playerId: "other" };
 
 test("バッテリーコマンドの場合は何もしない", () => {
@@ -31,7 +41,7 @@ test("バッテリーコマンドの場合は何もしない", () => {
     playerId: TEST_PLAYER.playerId,
     command: BATTERY_COMMAND,
   };
-  const result = activationOrNot(state, command);
+  const result = activateEffectOrNot(state, command);
   expect(result).toBeNull();
 });
 
@@ -44,7 +54,7 @@ test("バーストコマンドの場合は、バーストを発動する", () =>
     playerId: TEST_PLAYER.playerId,
     command: BURST_COMMAND,
   };
-  const result = activationOrNot(state, command);
+  const result = activateEffectOrNot(state, command);
   expect(result && result.effect.name === "BurstEffect").toBe(true);
 });
 
@@ -57,6 +67,6 @@ test("パイロットスキルコマンドの場合は、パイロットスキ�
     playerId: TEST_PLAYER.playerId,
     command: PILOT_SKILL_COMMAND,
   };
-  const result = activationOrNot(state, command);
+  const result = activateEffectOrNot(state, command);
   expect(result && result.effect.name === "PilotSkillEffect").toBe(true);
 });

--- a/test/game/progress/is-effect-activation-flow.test.ts
+++ b/test/game/progress/is-effect-activation-flow.test.ts
@@ -1,6 +1,6 @@
 import type { BatteryCommand, BurstCommand } from "../../../src";
 import type { PilotSkillCommand } from "../../../src/command/pilot-skill";
-import { isEffectActivationFlow } from "../../../src/game/progress/effect-activation-flow";
+import { isEffectActivationFlow } from "../../../src/game/progress/effect-activation-flow/is-effect-activation-flow";
 
 const BURST_COMMAND: BurstCommand = {
   type: "BURST_COMMAND",


### PR DESCRIPTION
This pull request refactors the effect activation flow in the game codebase by splitting the functionality into separate modules and updating the relevant tests. The most important changes include moving functions to new files, updating import paths, and renaming test files.

### Refactoring effect activation flow:

* [`src/game/progress/effect-activation-flow.ts`](diffhunk://#diff-806fb3524facd6e31d17b187922a3bc8de97b9500a363028e433d871a4946983L1-L84): Removed the entire file, including the `isEffectActivationFlow`, `activationOrNot`, and `effectActivationFlow` functions.
* [`src/game/progress/effect-activation-flow/activate-effect-or-not.ts`](diffhunk://#diff-4c549fb54dd86b23d10dad956694c56d5c69904983e7b6c43868e360e4e6b0aeR1-R26): Added the `activateEffectOrNot` function, which determines whether to activate an effect based on the command type.
* [`src/game/progress/effect-activation-flow/index.ts`](diffhunk://#diff-148081e28b449e3ad107233fa060365f73563a3a2da03e88d13e0470e11480b0R1-R47): Added the `effectActivationFlow` function, which handles the effect activation process for both attacker and defender commands.
* [`src/game/progress/effect-activation-flow/is-effect-activation-flow.ts`](diffhunk://#diff-5e39464f898e4ef85c5459b459f40f9a8e56b8f470f493d1af9b1fa28a33ad6cR1-R15): Added the `isEffectActivationFlow` function, which checks if the effect activation flow should be executed based on the command types.

### Updating import paths:

* [`src/game/progress/index.ts`](diffhunk://#diff-917ae51044ef8f5fd333311b19454572ab1226c942d0180251e05aa90e31b29fL5-R6): Updated the import paths for `effectActivationFlow` and `isEffectActivationFlow` to reflect their new locations.

### Renaming and updating tests:

* [`test/game/progress/activate-effect-or-not.test.ts`](diffhunk://#diff-c4b8698a1bb923197c7e2ca0a0d42316a92609f21444d8ceef3ba51a131fd293L1-R32): Renamed from `activation-or-not.test.ts` and updated to use the new `activateEffectOrNot` function. [[1]](diffhunk://#diff-c4b8698a1bb923197c7e2ca0a0d42316a92609f21444d8ceef3ba51a131fd293L1-R32) [[2]](diffhunk://#diff-c4b8698a1bb923197c7e2ca0a0d42316a92609f21444d8ceef3ba51a131fd293L34-R44) [[3]](diffhunk://#diff-c4b8698a1bb923197c7e2ca0a0d42316a92609f21444d8ceef3ba51a131fd293L47-R57) [[4]](diffhunk://#diff-c4b8698a1bb923197c7e2ca0a0d42316a92609f21444d8ceef3ba51a131fd293L60-R70)
* [`test/game/progress/is-effect-activation-flow.test.ts`](diffhunk://#diff-d783a60658ed63d7d2e6074bc195573663a94d18af8dddfe4e6cb9f58ebf0e22L3-R3): Updated to import `isEffectActivationFlow` from its new location.