### PR TITLE
1.33.0をリリース

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",


### PR DESCRIPTION
This pull request includes a version update in the `package.json` file for the `gbraver-burst-core` package. The version has been incremented from `1.32.1` to `1.33.0`. 

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `1.32.1` to `1.33.0`.