### PR TITLE
グランドーザのバーストを調整

### DIFF
--- a/src/effect/burst/force-turn-skip.ts
+++ b/src/effect/burst/force-turn-skip.ts
@@ -1,6 +1,11 @@
+import * as R from "ramda";
+
 import { ForceTurnEnd } from "../../player/burst/force-turn-end";
 import { PlayerState } from "../../state/player-state";
+import { removeContinuousActive } from "../continuous-active/remove-continuous-active";
 import { getRecoverBattery } from "../get-recover-battery";
+import { removeBatteryRecoverSkip } from "../remove-battery-recover-skip";
+import { removeTurnStartBatteryCorrect } from "../remove-turn-start-battery-correct";
 import { BurstInvokeParams } from "./burst-invoke-params";
 import { BurstInvokeResult } from "./burst-invoke-result";
 
@@ -18,6 +23,13 @@ const updateInvoker = (
   armdozer: {
     ...invoker.armdozer,
     battery: getRecoverBattery(invoker, burst.recoverBattery),
+    effects: [
+      ...R.pipe(
+        removeContinuousActive,
+        removeBatteryRecoverSkip,
+        removeTurnStartBatteryCorrect,
+      )(invoker.armdozer.effects),
+    ],
   },
 });
 

--- a/src/effect/burst/force-turn-skip.ts
+++ b/src/effect/burst/force-turn-skip.ts
@@ -2,7 +2,6 @@ import * as R from "ramda";
 
 import { ForceTurnEnd } from "../../player/burst/force-turn-end";
 import { PlayerState } from "../../state/player-state";
-import { removeContinuousActive } from "../continuous-active/remove-continuous-active";
 import { getRecoverBattery } from "../get-recover-battery";
 import { removeBatteryRecoverSkip } from "../remove-battery-recover-skip";
 import { removeTurnStartBatteryCorrect } from "../remove-turn-start-battery-correct";
@@ -25,7 +24,6 @@ const updateInvoker = (
     battery: getRecoverBattery(invoker, burst.recoverBattery),
     effects: [
       ...R.pipe(
-        removeContinuousActive,
         removeBatteryRecoverSkip,
         removeTurnStartBatteryCorrect,
       )(invoker.armdozer.effects),

--- a/src/master/armdozers/gran-dozer.ts
+++ b/src/master/armdozers/gran-dozer.ts
@@ -11,6 +11,6 @@ export const GranDozer: Armdozer = {
   speed: 800,
   burst: {
     type: "ForceTurnEnd",
-    recoverBattery: 2,
+    recoverBattery: 3,
   },
 };

--- a/test/effect/burst/force-turn-end.test.ts
+++ b/test/effect/burst/force-turn-end.test.ts
@@ -17,7 +17,25 @@ const burstPlayer: PlayerState = {
     enableBurst: true,
     battery: 1,
     maxBattery: 5,
-    effects: [EMPTY_ARMDOZER_EFFECT, EMPTY_ARMDOZER_EFFECT],
+    effects: [
+      EMPTY_ARMDOZER_EFFECT,
+      EMPTY_ARMDOZER_EFFECT,
+      {
+        type: "BatteryRecoverSkip",
+        period: {
+          type: "TurnLimit",
+          remainingTurn: 1,
+        },
+      },
+      {
+        type: "TurnStartBatteryCorrect",
+        correctBattery: 2,
+        period: {
+          type: "TurnLimit",
+          remainingTurn: 1,
+        },
+      },
+    ],
     burst: {
       type: "ForceTurnEnd",
       recoverBattery: 2,


### PR DESCRIPTION
This pull request includes changes to the `force-turn-skip` effect, updates to the `GranDozer` configuration, and modifications to the related unit tests. The most important changes include importing new utility functions, updating the battery recovery logic, and adjusting the `GranDozer` burst recovery value.

### Changes to `force-turn-skip` effect:

* [`src/effect/burst/force-turn-skip.ts`](diffhunk://#diff-bbc3272dfaef3656c804e414aaa99afc67dcea6bafba89844efb89e246b42f77R1-R7): Imported `removeBatteryRecoverSkip` and `removeTurnStartBatteryCorrect` utility functions.
* [`src/effect/burst/force-turn-skip.ts`](diffhunk://#diff-bbc3272dfaef3656c804e414aaa99afc67dcea6bafba89844efb89e246b42f77R25-R30): Updated the `updateInvoker` function to remove specific effects using the newly imported utility functions.

### Changes to `GranDozer` configuration:

* [`src/master/armdozers/gran-dozer.ts`](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1L14-R14): Changed the `recoverBattery` value in the `GranDozer` burst configuration from 2 to 3.

### Changes to unit tests:

* [`test/effect/burst/force-turn-end.test.ts`](diffhunk://#diff-c2c375dc19b70a4f19173067aaf50811adf11f8c8c121665981dbfee374abef3L20-R38): Added new effects (`BatteryRecoverSkip` and `TurnStartBatteryCorrect`) to the `burstPlayer` state to test the updated `force-turn-skip` logic .