### PR TITLE
code climateにテストカバレッジを連携するようにした

### DIFF
--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -1,0 +1,30 @@
+name: code climate
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 22.x ]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - name: Test & publish code coverage
+      uses: paambaati/codeclimate-action@v9.0.0
+      env:
+        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      with:
+        coverageCommand: npm run coverage
+        debug: true

--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -2,9 +2,9 @@ name: code climate
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ develop ]
 
 jobs:
   build:

--- a/Readme.md
+++ b/Readme.md
@@ -36,5 +36,12 @@ npm audit --omit=dev
 fixpack
 ```
 
+## GitHub Actions設定
+
+**secrets**
+| 変数名 | 値 |
+|-------|----|
+| CC_TEST_REPORTER_ID | code climate reporter id |
+
 ## License
 MIT

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "code-format-check:test": "prettier --check test",
     "code-format:src": "prettier --write src",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:src": "depcruise src",
     "dependency-check:test": "depcruise test",


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for Code Climate, updates the `Readme.md` with information about GitHub Actions secrets, and adds a new script for generating test coverage in `package.json`.

GitHub Actions Workflow:

* [`.github/workflows/code-climate.yml`](diffhunk://#diff-bc73f6179757c7f37680c46140388c3e36484ba6408a41c6b267abee0eb92daaR1-R30): Added a new workflow for Code Climate that runs on pushes and pull requests to the `master` and `develop` branches. The workflow sets up Node.js, installs dependencies, and runs tests to publish code coverage.

Documentation Update:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R39-R45): Added a section detailing the GitHub Actions secrets required for the new Code Climate workflow, including the `CC_TEST_REPORTER_ID` variable.

Test Coverage Script:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R55): Added a new script `"coverage": "jest --coverage"` to generate test coverage reports using Jest.