### PR TITLE
GBraverBurstCoreのユニットテストカバレッジを向上させた

### DIFF
--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -72,6 +72,21 @@ test("ステートヒストリーが空の場合にprogressを呼ぶと、例外
   }).toThrow();
 });
 
+test("選択不可能なコマンドを入力すると、例外が発生する", () => {
+  const core = startGBraverBurst([PLAYER1, PLAYER2]);
+  const player1BurstCommand: PlayerCommand = {
+    playerId: PLAYER1.playerId,
+    command: { type: "BURST_COMMAND" },
+  };
+  expect(() => {
+    // プレイヤー1がバーストコマンドを2回実行する
+    // バーストは1試合に1回しか使えないので2回目は選択不可能である
+    // よってこのケースでは例外が発生する
+    core.progress([player1BurstCommand, COMMAND2]);
+    core.progress([player1BurstCommand, COMMAND2]);
+  }).toThrow();
+});
+
 test("ゲームステート履歴が正しく更新される", () => {
   const core = startGBraverBurst([PLAYER1, PLAYER2]);
   const initialState = core.stateHistory();

--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -62,6 +62,16 @@ test("ゲームに参加しているプレイヤーのコマンドが存在し�
   }).toThrow();
 });
 
+test("ステートヒストリーが空の場合にprogressを呼ぶと、例外が発生する", () => {
+  const core = restoreGBraverBurst({
+    players: [PLAYER1, PLAYER2],
+    stateHistory: [],
+  });
+  expect(() => {
+    core.progress([COMMAND1, COMMAND2]);
+  }).toThrow();
+});
+
 test("ゲームステート履歴が正しく更新される", () => {
   const core = startGBraverBurst([PLAYER1, PLAYER2]);
   const initialState = core.stateHistory();

--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -2,7 +2,7 @@ import { PlayerCommand, RestoreGBraverBurstSchema } from "../../src";
 import { EMPTY_ARMDOZER } from "../../src/empty/armdozer";
 import { EMPTY_PILOT } from "../../src/empty/pilot";
 import { restoreGBraverBurst, startGBraverBurst } from "../../src/game";
-import type { Player } from "../../src/player/player";
+import { Player } from "../../src/player/player";
 
 /** プレイヤー1 */
 const PLAYER1: Player = {

--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -55,6 +55,13 @@ test("正しくゲームを進めることができる", () => {
   expect(result).toMatchSnapshot("progress");
 });
 
+test("ゲームに参加しているプレイヤーのコマンドが存在しない場合、例外が発生する", () => {
+  const core = startGBraverBurst([PLAYER1, PLAYER2]);
+  expect(() => {
+    core.progress([COMMAND1, { ...COMMAND2, playerId: "no-exist-player" }]);
+  }).toThrow();
+});
+
 test("ゲームステート履歴が正しく更新される", () => {
   const core = startGBraverBurst([PLAYER1, PLAYER2]);
   const initialState = core.stateHistory();

--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -42,6 +42,12 @@ test("初期状態を正しく作ることができる", () => {
   expect(result).toMatchSnapshot("initial-state");
 });
 
+test("同じIDをもつプレイヤーでゲーム開始すると、例外が発生する", () => {
+  expect(() => {
+    startGBraverBurst([PLAYER1, PLAYER1]);
+  }).toThrow();
+});
+
 test("プレイヤー情報が正しくセットされている", () => {
   const core = startGBraverBurst([PLAYER1, PLAYER2]);
   const result = core.players();


### PR DESCRIPTION
This pull request includes several updates to the test suite in `test/game/gbraver-burst-core.test.ts` to enhance the testing coverage and improve type imports.

### Improvements to type imports:

* Changed the import of `Player` from a type import to a regular import to ensure proper handling in the test file. (`[test/game/gbraver-burst-core.test.tsL5-R5](diffhunk://#diff-57aeefdd3b9dc8f42d186a90a935d33275699f41fa8381f2da64aa07b36c33dcL5-R5)`)

### Enhancements to test coverage:

* Added a test to verify that an exception is thrown when starting a game with players having the same ID. (`[test/game/gbraver-burst-core.test.tsR45-R50](diffhunk://#diff-57aeefdd3b9dc8f42d186a90a935d33275699f41fa8381f2da64aa07b36c33dcR45-R50)`)
* Added a test to check that an exception is thrown if a command from a non-existent player is processed. (`[test/game/gbraver-burst-core.test.tsR64-R95](diffhunk://#diff-57aeefdd3b9dc8f42d186a90a935d33275699f41fa8381f2da64aa07b36c33dcR64-R95)`)
* Added a test to ensure an exception is thrown when `progress` is called with an empty state history. (`[test/game/gbraver-burst-core.test.tsR64-R95](diffhunk://#diff-57aeefdd3b9dc8f42d186a90a935d33275699f41fa8381f2da64aa07b36c33dcR64-R95)`)
* Added a test to confirm that an exception is thrown when an invalid command is input, such as a player executing a burst command more than once per match. (`[test/game/gbraver-burst-core.test.tsR64-R95](diffhunk://#diff-57aeefdd3b9dc8f42d186a90a935d33275699f41fa8381f2da64aa07b36c33dcR64-R95)`)