### PR TITLE
codeclimate系GitHub Actionsを改善

### DIFF
--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -7,7 +7,7 @@ on:
     branches: [ develop ]
 
 jobs:
-  build:
+  coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Readme.md
+++ b/Readme.md
@@ -38,8 +38,12 @@ fixpack
 
 ## GitHub Actions設定
 
+### Secrets設定
+[ここ](https://docs.github.com/ja/actions/security-guides/using-secrets-in-github-actions)を参考にGitHub ActionsのSecretsを設定する。
+以下が設定内容である。
+
 **secrets**
-| 変数名 | 値 |
+| シークレット名 | 値 |
 |-------|----|
 | CC_TEST_REPORTER_ID | code climate reporter id |
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and updates to the `Readme.md` file. The most important changes are the renaming of the `build` job to `coverage` in the GitHub Actions workflow and the addition of instructions for setting up GitHub Actions secrets in the `Readme.md` file.

Changes to GitHub Actions workflow:

* [`.github/workflows/code-climate.yml`](diffhunk://#diff-bc73f6179757c7f37680c46140388c3e36484ba6408a41c6b267abee0eb92daaL10-R10): Renamed the `build` job to `coverage`.

Documentation updates:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R41-R46): Added a new section for setting up GitHub Actions secrets, including a reference link and a table for the secret names and values.