### PR TITLE
攻撃補正効果、テストをリファクタリングした

### DIFF
--- a/src/effect/correct-power.ts
+++ b/src/effect/correct-power.ts
@@ -1,20 +1,7 @@
-import type { ArmdozerEffect } from "../state/armdozer-effect";
-
-/**
- * 攻撃補正を計算する
- *
- * @param effects アームドーザ効果
- * @returns 計算結果
- */
-export function correctPower(effects: ArmdozerEffect[]): number {
-  const total = totalCorrectPower(effects);
-  const coefficient = hasHalveCorrectPower(effects) ? 0.5 : 1;
-  return total * coefficient;
-}
+import { ArmdozerEffect } from "../state/armdozer-effect";
 
 /**
  * 攻撃補正半減を持つか否かを判定する
- *
  * @param effects 攻撃側のアームドーザ効果
  * @returns 判定結果、trueで攻撃補正半減を持つ
  */
@@ -24,7 +11,6 @@ export function hasHalveCorrectPower(effects: ArmdozerEffect[]): boolean {
 
 /**
  * アームドーザ効果から攻撃補正の合計値を計算する
- *
  * @param effects 攻撃側のアームドーザ効果
  * @returns 計算結果
  */
@@ -32,4 +18,15 @@ export function totalCorrectPower(effects: ArmdozerEffect[]): number {
   return effects
     .map((v) => (v.type === "CorrectPower" ? v.power : 0))
     .reduce((a, b) => a + b, 0);
+}
+
+/**
+ * 攻撃補正を計算する
+ * @param effects アームドーザ効果
+ * @returns 計算結果
+ */
+export function correctPower(effects: ArmdozerEffect[]): number {
+  const total = totalCorrectPower(effects);
+  const coefficient = hasHalveCorrectPower(effects) ? 0.5 : 1;
+  return total * coefficient;
 }

--- a/test/effect/correct-power.test.ts
+++ b/test/effect/correct-power.test.ts
@@ -1,25 +1,25 @@
 import { correctPower } from "../../src";
 import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
 import { HalveCorrectPower } from "../../src/state/armdozer-effect/halve-correct-power";
-import { TurnLimitEffect } from "../../src/state/armdozer-effect/turn-limit-effect";
 
-const oneTurn: TurnLimitEffect = {
-  type: "TurnLimit",
-  remainingTurn: 1,
-};
+/** 攻撃補正半減 */
 const halveCorrect: HalveCorrectPower = {
   type: "HalveCorrectPower",
-  period: oneTurn,
+  period: { type: "TurnLimit", remainingTurn: 1 },
 };
+
+/** 攻撃+1000 */
 const plusCorrect: CorrectPower = {
   type: "CorrectPower",
   power: 1000,
-  period: oneTurn,
+  period: { type: "TurnLimit", remainingTurn: 1 },
 };
+
+/** 攻撃-1000 */
 const minusCorrect: CorrectPower = {
   type: "CorrectPower",
   power: -1000,
-  period: oneTurn,
+  period: { type: "TurnLimit", remainingTurn: 1 },
 };
 
 test("攻撃補正半減効果を持たない場合、攻撃補正効果の合計が最終的な値になる", () => {


### PR DESCRIPTION
This pull request includes changes to the `correct-power` module and its associated tests to refactor the code and improve clarity. The most important changes include moving the `correctPower` function within the same file and updating the test cases to use inline period definitions.

Refactoring and code clarity improvements:

* [`src/effect/correct-power.ts`](diffhunk://#diff-32f75e8cc1a705e823fdf7dee8ef354678f9f0d09a7eb28a63c9703a99005f1fL1-L17): Moved the `correctPower` function to the end of the file for better organization and clarity. [[1]](diffhunk://#diff-32f75e8cc1a705e823fdf7dee8ef354678f9f0d09a7eb28a63c9703a99005f1fL1-L17) [[2]](diffhunk://#diff-32f75e8cc1a705e823fdf7dee8ef354678f9f0d09a7eb28a63c9703a99005f1fR22-R32)

Test case updates:

* [`test/effect/correct-power.test.ts`](diffhunk://#diff-9ddfe932d8889ee5b330942c7b56bf841bd4ad9ce8312115949725367ab3fffbL4-R22): Updated test cases to use inline period definitions instead of predefined `TurnLimitEffect` objects. This change improves readability and maintainability of the test code.