### PR TITLE
ダメージ反射フローをリファクタリングした

### DIFF
--- a/src/game/progress/battle-flow/reflect-flow.ts
+++ b/src/game/progress/battle-flow/reflect-flow.ts
@@ -1,9 +1,9 @@
-import type { BattleResult } from "../../../effect/battle/result/battle-result";
+import { BattleResult } from "../../../effect/battle/result/battle-result";
 import { reflect } from "../../../effect/reflect";
-import type { ReflectParam } from "../../../effect/reflect/reflect";
+import { ReflectParam } from "../../../effect/reflect/reflect";
 import { toReflectParam } from "../../../effect/reflect/to-reflect-param";
-import type { PlayerId } from "../../../player/player";
-import type { GameState } from "../../../state/game-state";
+import { PlayerId } from "../../../player/player";
+import { GameState } from "../../../state/game-state";
 
 /**
  * ダメージ反射フローを実行できるか否かを判定する
@@ -20,7 +20,6 @@ export function canReflectFlow(result: BattleResult): boolean {
 
 /**
  * ダメージ反射フロー
- *
  * @param lastState 最新のゲームステート
  * @param attackerId 攻撃側のプレイヤーID
  * @returns 更新結果
@@ -30,7 +29,6 @@ export function reflectFlow(
   attackerId: PlayerId,
 ): GameState[] {
   const defender = lastState.players.find((v) => v.playerId !== attackerId);
-
   if (!defender) {
     throw new Error("not found defender");
   }

--- a/test/game/progress/battle-flow/can-reflect-flow.test.ts
+++ b/test/game/progress/battle-flow/can-reflect-flow.test.ts
@@ -1,37 +1,42 @@
-import type { BattleResult } from "../../../../src";
+import { CriticalHit, Feint, Guard, Miss, NormalHit } from "../../../../src";
 import { canReflectFlow } from "../../../../src/game/progress/battle-flow/reflect-flow";
 
+/** 通常ヒット */
+const normalHit: NormalHit = { name: "NormalHit", damage: 2000 };
+
+/** ガード */
+const guard: Guard = { name: "Guard", damage: 1000 };
+
+/** クリティカル */
+const criticalHit: CriticalHit = { name: "CriticalHit", damage: 9999 };
+
+/** ミス */
+const miss: Miss = { name: "Miss" };
+
+/** フェイント */
+const feint: Feint = { name: "Feint", isDefenderMoved: true };
+
 test("通常ヒットの場合はダメージ反射を行う", () => {
-  const battleResult: BattleResult = {
-    name: "NormalHit",
-    damage: 1000,
-  };
-  const result = canReflectFlow(battleResult);
+  const result = canReflectFlow(normalHit);
   expect(result).toBe(true);
 });
 
 test("ガードの場合はダメージ反射を行う", () => {
-  const battleResult: BattleResult = {
-    name: "Guard",
-    damage: 1000,
-  };
-  const result = canReflectFlow(battleResult);
+  const result = canReflectFlow(guard);
   expect(result).toBe(true);
 });
 
 test("クリティカルの場合はダメージ反射を行う", () => {
-  const battleResult: BattleResult = {
-    name: "CriticalHit",
-    damage: 1000,
-  };
-  const result = canReflectFlow(battleResult);
+  const result = canReflectFlow(criticalHit);
   expect(result).toBe(true);
 });
 
 test("ミスの場合はダメージ反射をしない", () => {
-  const battleResult: BattleResult = {
-    name: "Miss",
-  };
-  const result = canReflectFlow(battleResult);
+  const result = canReflectFlow(miss);
+  expect(result).toBe(false);
+});
+
+test("フェイントの場合はダメージ反射をしない", () => {
+  const result = canReflectFlow(feint);
   expect(result).toBe(false);
 });


### PR DESCRIPTION
This pull request includes several changes to the `src/game/progress/battle-flow/reflect-flow.ts` file and its associated test file. The changes primarily involve removing type-only imports and adding new test cases to improve the test coverage for the `canReflectFlow` function.

Improvements to type imports:

* [`src/game/progress/battle-flow/reflect-flow.ts`](diffhunk://#diff-66ab6ff6b6ff3c721d29425e6b5621d7fa7917c0cd7386ef1be0e69e66c10becL1-R6): Changed type-only imports to regular imports for `BattleResult`, `ReflectParam`, `PlayerId`, and `GameState`.

Enhancements to test cases:

* [`test/game/progress/battle-flow/can-reflect-flow.test.ts`](diffhunk://#diff-b98878b8d27bbbb389f0b45be9ff0955e064e108aefe9e7737ebc2d38f449035L1-R40): Replaced inline `BattleResult` objects with predefined constants for `NormalHit`, `Guard`, `CriticalHit`, `Miss`, and `Feint`. Added new test cases for `Miss` and `Feint` to ensure they do not trigger damage reflection.