### PR TITLE
グランドーザのバーストを変更した

### DIFF
--- a/src/master/armdozers/gran-dozer.ts
+++ b/src/master/armdozers/gran-dozer.ts
@@ -10,7 +10,7 @@ export const GranDozer: Armdozer = {
   power: 3000,
   speed: 800,
   burst: {
-    type: "ForceTurnEnd",
+    type: "Ineffective",
     recoverBattery: 3,
   },
 };


### PR DESCRIPTION
This pull request includes a small change to the `GranDozer` configuration in the `src/master/armdozers/gran-dozer.ts` file. The change modifies the `burst` type from `"ForceTurnEnd"` to `"Ineffective"`.

* [`src/master/armdozers/gran-dozer.ts`](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1L13-R13): Modified the `burst` type from `"ForceTurnEnd"` to `"Ineffective"`.