### PR TITLE
Release/1.35.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",

--- a/src/master/armdozers/gran-dozer.ts
+++ b/src/master/armdozers/gran-dozer.ts
@@ -5,12 +5,12 @@ import { ArmdozerIds } from "./armdozer-ids";
 export const GranDozer: Armdozer = {
   id: ArmdozerIds.GRAN_DOZER,
   name: "グランドーザ",
-  maxHp: 3300,
+  maxHp: 3500,
   maxBattery: 5,
   power: 3000,
-  speed: 800,
+  speed: 600,
   burst: {
     type: "Ineffective",
-    recoverBattery: 3,
+    recoverBattery: 2,
   },
 };


### PR DESCRIPTION
This pull request includes a version update and adjustments to the `GranDozer` configuration in the `gbraver-burst-core` package. The most important changes include updating the package version and modifying the attributes of the `GranDozer` object.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `1.35.0` to `1.35.1`.

GranDozer configuration adjustments:

* [`src/master/armdozers/gran-dozer.ts`](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1L8-R14): Increased `maxHp` from 3300 to 3500.
* [`src/master/armdozers/gran-dozer.ts`](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1L8-R14): Decreased `speed` from 800 to 600.
* [`src/master/armdozers/gran-dozer.ts`](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1L8-R14): Decreased `recoverBattery` in the `burst` object from 3 to 2.