### PR TITLE
npm publishのワークフローを追加した

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [ published ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ fixpack
 | シークレット名 | 値 |
 |-------|----|
 | CC_TEST_REPORTER_ID | code climate reporter id |
+| NPM_TOKEN | npmの[Personal Access Token](https://docs.npmjs.com/creating-and-viewing-access-tokens)  |
 
 ## License
 MIT


### PR DESCRIPTION
This pull request includes changes to automate the process of publishing packages to npm and updates the documentation to include the necessary secret for npm authentication.

### Automation of npm package publishing:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240R1-R21): Added a new GitHub Actions workflow to publish the package to npm when a release is published. This workflow includes steps for checking out the repository, setting up Node.js, and running the `npm publish` command with the appropriate authentication token.

### Documentation update:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R49): Added the `NPM_TOKEN` secret to the list of required secrets, providing a link to the npm documentation for creating and viewing personal access tokens.