### PR TITLE
TurnChangeにreadonを追加した

### DIFF
--- a/src/effect/continuous-active/index.ts
+++ b/src/effect/continuous-active/index.ts
@@ -49,6 +49,7 @@ export function continuousActive(state: GameState): GameStateX<TurnChange> {
   const effect: TurnChange = {
     name: "TurnChange",
     recoverBattery: 0,
+    reason: "ContinuousActive",
   };
   return { ...state, players: updatedPlayers, effect };
 }

--- a/src/effect/turn-change/index.ts
+++ b/src/effect/turn-change/index.ts
@@ -54,7 +54,7 @@ export function turnChange(lastState: GameState): GameStateX<TurnChange> {
     effect: {
       name: "TurnChange",
       recoverBattery,
-      reason: "TurnEnd",
+      reason: "Normal",
     },
   };
 }

--- a/src/effect/turn-change/index.ts
+++ b/src/effect/turn-change/index.ts
@@ -54,6 +54,7 @@ export function turnChange(lastState: GameState): GameStateX<TurnChange> {
     effect: {
       name: "TurnChange",
       recoverBattery,
+      reason: "TurnEnd",
     },
   };
 }

--- a/src/effect/turn-change/turn-change.ts
+++ b/src/effect/turn-change/turn-change.ts
@@ -6,12 +6,12 @@ export type TurnChange = Readonly<{
   /** バッテリー回復量 */
   recoverBattery: number;
   /** ターン変更の理由 */
-  reason: "TurnEnd" | "ContinuousActive";
+  reason: "Normal" | "ContinuousActive";
 }>;
 
 /** TurnChange zodスキーマ */
 export const TurnChangeSchema: z.ZodSchema<TurnChange> = z.object({
   name: z.literal("TurnChange"),
   recoverBattery: z.number(),
-  reason: z.union([z.literal("TurnEnd"), z.literal("ContinuousActive")]),
+  reason: z.union([z.literal("Normal"), z.literal("ContinuousActive")]),
 });

--- a/src/effect/turn-change/turn-change.ts
+++ b/src/effect/turn-change/turn-change.ts
@@ -5,10 +5,13 @@ export type TurnChange = Readonly<{
   name: "TurnChange";
   /** バッテリー回復量 */
   recoverBattery: number;
+  /** ターン変更の理由 */
+  reason: "TurnEnd" | "ContinuousActive";
 }>;
 
 /** TurnChange zodスキーマ */
 export const TurnChangeSchema: z.ZodSchema<TurnChange> = z.object({
   name: z.literal("TurnChange"),
   recoverBattery: z.number(),
+  reason: z.union([z.literal("TurnEnd"), z.literal("ContinuousActive")]),
 });

--- a/test/effect/continous-active/__snapshots__/continuous-active.test.ts.snap
+++ b/test/effect/continous-active/__snapshots__/continuous-active.test.ts.snap
@@ -5,6 +5,7 @@ exports[`BatteryRecoverSkip、TurnStartBatteryCorrectは取り除かれる 1`] =
   "activePlayerId": "attacker",
   "effect": {
     "name": "TurnChange",
+    "reason": "ContinuousActive",
     "recoverBattery": 0,
   },
   "players": [
@@ -97,6 +98,7 @@ exports[`アクティブプレイヤー継続が正しく処理できる 1`] = `
   "activePlayerId": "attacker",
   "effect": {
     "name": "TurnChange",
+    "reason": "ContinuousActive",
     "recoverBattery": 0,
   },
   "players": [

--- a/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
+++ b/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
@@ -5,7 +5,7 @@ exports[`BatteryRecoverSkipがある場合は、バッテリー回復しない: 
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
-    "reason": "TurnEnd",
+    "reason": "Normal",
     "recoverBattery": 0,
   },
   "players": [
@@ -76,7 +76,7 @@ exports[`TurnStartBatteryCorrectがある場合、回復量が補正される: t
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
-    "reason": "TurnEnd",
+    "reason": "Normal",
     "recoverBattery": 4,
   },
   "players": [
@@ -147,7 +147,7 @@ exports[`ターン交代が正しく処理できる: has-no-effects 1`] = `
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
-    "reason": "TurnEnd",
+    "reason": "Normal",
     "recoverBattery": 3,
   },
   "players": [

--- a/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
+++ b/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
@@ -5,6 +5,7 @@ exports[`BatteryRecoverSkipがある場合は、バッテリー回復しない: 
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
+    "reason": "TurnEnd",
     "recoverBattery": 0,
   },
   "players": [
@@ -75,6 +76,7 @@ exports[`TurnStartBatteryCorrectがある場合、回復量が補正される: t
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
+    "reason": "TurnEnd",
     "recoverBattery": 4,
   },
   "players": [
@@ -145,6 +147,7 @@ exports[`ターン交代が正しく処理できる: has-no-effects 1`] = `
   "activePlayerId": "defender",
   "effect": {
     "name": "TurnChange",
+    "reason": "TurnEnd",
     "recoverBattery": 3,
   },
   "players": [

--- a/test/effect/turn-change/turn-change-schema.test.ts
+++ b/test/effect/turn-change/turn-change-schema.test.ts
@@ -1,4 +1,7 @@
-import { TurnChange, TurnChangeSchema } from "../../../src/effect/turn-change/turn-change";
+import {
+  TurnChange,
+  TurnChangeSchema,
+} from "../../../src/effect/turn-change/turn-change";
 
 // reason: "TurnEnd" のTurnChange
 const turnEnd: TurnChange = {

--- a/test/effect/turn-change/turn-change-schema.test.ts
+++ b/test/effect/turn-change/turn-change-schema.test.ts
@@ -1,14 +1,30 @@
-import { TurnChangeSchema } from "../../../src";
-import { validTurnChange } from "./valid-turn-change";
+import { TurnChange, TurnChangeSchema } from "../../../src/effect/turn-change/turn-change";
 
-test("TurnChangeはパースできる", () => {
-  expect(TurnChangeSchema.parse(validTurnChange)).toEqual(validTurnChange);
+// reason: "TurnEnd" のTurnChange
+const turnEnd: TurnChange = {
+  name: "TurnChange",
+  recoverBattery: 3,
+  reason: "TurnEnd",
+};
+// reason: "ContinuousActive" のTurnChange
+const continuousActive: TurnChange = {
+  name: "TurnChange",
+  recoverBattery: 0,
+  reason: "ContinuousActive",
+};
+
+test("reason: 'TurnEnd' のTurnChangeはパースできる", () => {
+  expect(TurnChangeSchema.parse(turnEnd)).toEqual(turnEnd);
+});
+
+test("reason: 'ContinuousActive' のTurnChangeはパースできる", () => {
+  expect(TurnChangeSchema.parse(continuousActive)).toEqual(continuousActive);
 });
 
 test("文字からJSONパースしたオブジェクトでも、正しくパースできる", () => {
-  const str = JSON.stringify(validTurnChange);
+  const str = JSON.stringify(turnEnd);
   const data = JSON.parse(str);
-  expect(TurnChangeSchema.parse(data)).toEqual(validTurnChange);
+  expect(TurnChangeSchema.parse(data)).toEqual(turnEnd);
 });
 
 test("TurnChange以外はパースできない", () => {

--- a/test/effect/turn-change/turn-change-schema.test.ts
+++ b/test/effect/turn-change/turn-change-schema.test.ts
@@ -3,21 +3,22 @@ import {
   TurnChangeSchema,
 } from "../../../src/effect/turn-change/turn-change";
 
-// reason: "TurnEnd" のTurnChange
-const turnEnd: TurnChange = {
+/** reason: "Normal" のTurnChange */
+const normal: TurnChange = {
   name: "TurnChange",
   recoverBattery: 3,
-  reason: "TurnEnd",
+  reason: "Normal",
 };
-// reason: "ContinuousActive" のTurnChange
+
+/** reason: "ContinuousActive" のTurnChange */
 const continuousActive: TurnChange = {
   name: "TurnChange",
   recoverBattery: 0,
   reason: "ContinuousActive",
 };
 
-test("reason: 'TurnEnd' のTurnChangeはパースできる", () => {
-  expect(TurnChangeSchema.parse(turnEnd)).toEqual(turnEnd);
+test("reason: 'Normal' のTurnChangeはパースできる", () => {
+  expect(TurnChangeSchema.parse(normal)).toEqual(normal);
 });
 
 test("reason: 'ContinuousActive' のTurnChangeはパースできる", () => {
@@ -25,9 +26,9 @@ test("reason: 'ContinuousActive' のTurnChangeはパースできる", () => {
 });
 
 test("文字からJSONパースしたオブジェクトでも、正しくパースできる", () => {
-  const str = JSON.stringify(turnEnd);
+  const str = JSON.stringify(normal);
   const data = JSON.parse(str);
-  expect(TurnChangeSchema.parse(data)).toEqual(turnEnd);
+  expect(TurnChangeSchema.parse(data)).toEqual(normal);
 });
 
 test("TurnChange以外はパースできない", () => {

--- a/test/effect/turn-change/valid-turn-change.ts
+++ b/test/effect/turn-change/valid-turn-change.ts
@@ -4,5 +4,5 @@ import { TurnChange } from "../../../src";
 export const validTurnChange: TurnChange = {
   name: "TurnChange",
   recoverBattery: 3,
-  reason: "TurnEnd",
+  reason: "Normal",
 };

--- a/test/effect/turn-change/valid-turn-change.ts
+++ b/test/effect/turn-change/valid-turn-change.ts
@@ -4,4 +4,5 @@ import { TurnChange } from "../../../src";
 export const validTurnChange: TurnChange = {
   name: "TurnChange",
   recoverBattery: 3,
+  reason: "TurnEnd",
 };

--- a/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
+++ b/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
@@ -496,7 +496,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
     "activePlayerId": "player1",
     "effect": {
       "name": "TurnChange",
-      "reason": "TurnEnd",
+      "reason": "Normal",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
+++ b/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
@@ -496,6 +496,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
     "activePlayerId": "player1",
     "effect": {
       "name": "TurnChange",
+      "reason": "TurnEnd",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/__snapshots__/progress.test.ts.snap
+++ b/test/game/progress/__snapshots__/progress.test.ts.snap
@@ -593,6 +593,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
+      "reason": "TurnEnd",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/__snapshots__/progress.test.ts.snap
+++ b/test/game/progress/__snapshots__/progress.test.ts.snap
@@ -593,7 +593,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
-      "reason": "TurnEnd",
+      "reason": "Normal",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
@@ -858,6 +858,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
+      "reason": "TurnEnd",
       "recoverBattery": 3,
     },
     "players": [
@@ -1339,6 +1340,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
+      "reason": "TurnEnd",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
@@ -858,7 +858,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
-      "reason": "TurnEnd",
+      "reason": "Normal",
       "recoverBattery": 3,
     },
     "players": [
@@ -1340,7 +1340,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
     "activePlayerId": "defender",
     "effect": {
       "name": "TurnChange",
-      "reason": "TurnEnd",
+      "reason": "Normal",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
@@ -80,6 +80,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
     "activePlayerId": "player1",
     "effect": {
       "name": "TurnChange",
+      "reason": "ContinuousActive",
       "recoverBattery": 0,
     },
     "players": [
@@ -351,6 +352,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
     "activePlayerId": "player1",
     "effect": {
       "name": "TurnChange",
+      "reason": "TurnEnd",
       "recoverBattery": 3,
     },
     "players": [

--- a/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
@@ -352,7 +352,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
     "activePlayerId": "player1",
     "effect": {
       "name": "TurnChange",
-      "reason": "TurnEnd",
+      "reason": "Normal",
       "recoverBattery": 3,
     },
     "players": [


### PR DESCRIPTION
This pull request introduces a new `reason` property to the `TurnChange` type and updates related logic and tests accordingly. The `reason` property indicates why a turn change occurred, with possible values being `"Normal"` or `"ContinuousActive"`. This change enhances the clarity of game state transitions.

### Core Changes to `TurnChange` Type:
* Added a `reason` property to the `TurnChange` type, with possible values `"Normal"` or `"ContinuousActive"`. Updated the `TurnChangeSchema` to validate this new property. (`src/effect/turn-change/turn-change.ts` - [src/effect/turn-change/turn-change.tsR8-R16](diffhunk://#diff-4ab62cffac9d04b178ab2c2dda299ad45c1b8f42df2dfa0847828c755f752d2fR8-R16))

### Updates to Game Logic:
* Modified the `continuousActive` and `turnChange` functions to include the appropriate `reason` value in the `TurnChange` effect. (`src/effect/continuous-active/index.ts` - [[1]](diffhunk://#diff-0602831db52407c4d883016b0ae9ad59f5f24c6e5c31062a210652fa80a7ccb8R52) `src/effect/turn-change/index.ts` - [[2]](diffhunk://#diff-5cf95ffe35b52a4abb21fef9241af56fa8869ead95f3720ad692e4929feb8710R57)

### Test Updates:
* Updated snapshot tests across multiple files to include the `reason` property in the `TurnChange` effect. (`test/effect/continous-active/__snapshots__/continuous-active.test.ts.snap` - [[1]](diffhunk://#diff-a8c2776970ea51617054b2883d877aa6bb08bd46a817eafdb4f17664bf88e2abR8) [[2]](diffhunk://#diff-a8c2776970ea51617054b2883d877aa6bb08bd46a817eafdb4f17664bf88e2abR101); `test/effect/turn-change/__snapshots__/turn-change.test.ts.snap` - [[3]](diffhunk://#diff-2e7c97f4dbd6a073514bb3a7eeb4cf96644a7a5d07b6a9ead2005f01232a0498R8) [[4]](diffhunk://#diff-2e7c97f4dbd6a073514bb3a7eeb4cf96644a7a5d07b6a9ead2005f01232a0498R79) [[5]](diffhunk://#diff-2e7c97f4dbd6a073514bb3a7eeb4cf96644a7a5d07b6a9ead2005f01232a0498R150); `test/game/__snapshots__/gbraver-burst-core.test.ts.snap` - [[6]](diffhunk://#diff-63ef7d14e509758091f7e0edc27c533feea51368c2bcc104b101c3ceadf14a98R499); and others)
* Refactored and expanded unit tests for `TurnChangeSchema` to verify parsing of both `"Normal"` and `"ContinuousActive"` reasons. (`test/effect/turn-change/turn-change-schema.test.ts` - [test/effect/turn-change/turn-change-schema.test.tsL1-R31](diffhunk://#diff-0e95f1b58c8feb96155f07772c93e3cebb73f3c9dfbbc99c5defc209ab670716L1-R31))
* Updated the `validTurnChange` fixture to include the `reason` property. (`test/effect/turn-change/valid-turn-change.ts` - [test/effect/turn-change/valid-turn-change.tsR7](diffhunk://#diff-908bdb45e303c1dbd89d52895c52d2d9f6368d67024924c752bfc39e52641ad8R7))