### PR TITLE
アームドーザのステータスにbatteryAutoRecoveryを追加した

### DIFF
--- a/src/effect/turn-change/recover-battery-on-turn-start.ts
+++ b/src/effect/turn-change/recover-battery-on-turn-start.ts
@@ -1,9 +1,6 @@
 import { PlayerState } from "../../state/player-state";
 import { getRecoverBattery } from "../get-recover-battery";
 
-/** ターン開始時に回復するバッテリーの基礎値 */
-const BASIC_BATTERY_RECOVER = 3;
-
 /** バッテリー回復結果 */
 type RecoverBatteryResult = {
   /** バッテリー回復量 */
@@ -31,7 +28,7 @@ const onBatteryRecover = (player: PlayerState) => {
   const correct = player.armdozer.effects
     .map((e) => (e.type === "TurnStartBatteryCorrect" ? e.correctBattery : 0))
     .reduce((total, v) => total + v, 0);
-  const recoverBattery = BASIC_BATTERY_RECOVER + correct;
+  const recoverBattery = player.armdozer.batteryAutoRecovery + correct;
   const battery = getRecoverBattery(player, recoverBattery);
   return { recoverBattery, battery };
 };

--- a/src/empty/armdozer.ts
+++ b/src/empty/armdozer.ts
@@ -15,6 +15,7 @@ export const EMPTY_ARMDOZER: Armdozer = {
   name: "name",
   maxHp: 3000,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 2000,
   speed: 2000,
   burst: EMPTY_BURST,

--- a/src/master/armdozers/dino-dozer.ts
+++ b/src/master/armdozers/dino-dozer.ts
@@ -7,6 +7,7 @@ export const DinoDozer: Armdozer = {
   name: "ダイナドーザ",
   maxHp: 2600,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 2000,
   speed: 2500,
   burst: {

--- a/src/master/armdozers/genesis-braver.ts
+++ b/src/master/armdozers/genesis-braver.ts
@@ -7,6 +7,7 @@ export const GenesisBraver: Armdozer = {
   name: "ジェネシスブレイバー",
   maxHp: 3000,
   maxBattery: 4,
+  batteryAutoRecovery: 3,
   power: 2200,
   speed: 1900,
   burst: {

--- a/src/master/armdozers/gran-dozer.ts
+++ b/src/master/armdozers/gran-dozer.ts
@@ -7,6 +7,7 @@ export const GranDozer: Armdozer = {
   name: "グランドーザ",
   maxHp: 3400,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 3000,
   speed: 700,
   burst: {

--- a/src/master/armdozers/lightning-dozer.ts
+++ b/src/master/armdozers/lightning-dozer.ts
@@ -7,6 +7,7 @@ export const LightningDozer: Armdozer = {
   name: "ライトニングドーザ",
   maxHp: 3400,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 1900,
   speed: 1800,
   burst: {

--- a/src/master/armdozers/neo-landozer.ts
+++ b/src/master/armdozers/neo-landozer.ts
@@ -7,6 +7,7 @@ export const NeoLandozer: Armdozer = {
   name: "ネオランドーザ",
   maxHp: 3300,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 2300,
   speed: 1500,
   burst: {

--- a/src/master/armdozers/shin-braver.ts
+++ b/src/master/armdozers/shin-braver.ts
@@ -7,6 +7,7 @@ export const ShinBraver: Armdozer = {
   name: "シンブレイバー",
   maxHp: 3100,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 2000,
   speed: 2000,
   burst: {

--- a/src/master/armdozers/wing-dozer.ts
+++ b/src/master/armdozers/wing-dozer.ts
@@ -7,6 +7,7 @@ export const WingDozer: Armdozer = {
   name: "ウィングドーザ",
   maxHp: 2700,
   maxBattery: 5,
+  batteryAutoRecovery: 3,
   power: 2200,
   speed: 2200,
   burst: {

--- a/src/player/armdozer.ts
+++ b/src/player/armdozer.ts
@@ -21,6 +21,8 @@ export type ArmdozerX<X> = Readonly<{
   maxHp: number;
   /** 最大バッテリー */
   maxBattery: number;
+  /** バッテリー自動回復量 */
+  batteryAutoRecovery: number;
   /** 攻撃 */
   power: number;
   /** スピード */
@@ -38,6 +40,7 @@ export const ArmdozerSchema = z.object({
   name: z.string(),
   maxHp: z.number(),
   maxBattery: z.number(),
+  batteryAutoRecovery: z.number(),
   power: z.number(),
   speed: z.number(),
   burst: BurstSchema,

--- a/test/effect/burst/__snapshots__/battery-drain.test.ts.snap
+++ b/test/effect/burst/__snapshots__/battery-drain.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バッテリードレインが正しく適用できる 1`] = `
 {
@@ -16,6 +16,7 @@ exports[`バッテリードレインが正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -62,6 +63,7 @@ exports[`バッテリードレインが正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "batteryDecrease": -2,
           "recoverBattery": 2,

--- a/test/effect/burst/__snapshots__/battery-limit-break.test.ts.snap
+++ b/test/effect/burst/__snapshots__/battery-limit-break.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バッテリーリミットブレイクが正しく適用できる 1`] = `
 {
@@ -16,6 +16,7 @@ exports[`バッテリーリミットブレイクが正しく適用できる 1`] 
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -45,6 +46,7 @@ exports[`バッテリーリミットブレイクが正しく適用できる 1`] 
     {
       "armdozer": {
         "battery": 8,
+        "batteryAutoRecovery": 3,
         "burst": {
           "maxBattery": 8,
           "recoverBattery": 8,

--- a/test/effect/burst/__snapshots__/buff-power.test.ts.snap
+++ b/test/effect/burst/__snapshots__/buff-power.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`攻撃力バフが正しく適用される 1`] = `
 {
@@ -17,6 +17,7 @@ exports[`攻撃力バフが正しく適用される 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -46,6 +47,7 @@ exports[`攻撃力バフが正しく適用される 1`] = `
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "buffPower": 1000,
           "duration": 2,

--- a/test/effect/burst/__snapshots__/continuous-attack.test.ts.snap
+++ b/test/effect/burst/__snapshots__/continuous-attack.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`連続攻撃バーストが正しく適用できる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`連続攻撃バーストが正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`連続攻撃バーストが正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 3,
           "type": "ContinuousAttack",

--- a/test/effect/burst/__snapshots__/effect-clear.test.ts.snap
+++ b/test/effect/burst/__snapshots__/effect-clear.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`効果クリアを適用したので、相手の効果だけが削除される 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`効果クリアを適用したので、相手の効果だけが削除�
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`効果クリアを適用したので、相手の効果だけが削除�
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 2,
           "type": "EffectClear",

--- a/test/effect/burst/__snapshots__/force-turn-end.test.ts.snap
+++ b/test/effect/burst/__snapshots__/force-turn-end.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`相手ターンに強制ターンエンドを発動した場合、自分が攻撃プレイヤーになる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`相手ターンに強制ターンエンドを発動した場合、自�
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`相手ターンに強制ターンエンドを発動した場合、自�
     {
       "armdozer": {
         "battery": 3,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 2,
           "type": "ForceTurnEnd",
@@ -103,6 +105,7 @@ exports[`自分ターンに強制ターンエンドを発動した場合、引�
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -132,6 +135,7 @@ exports[`自分ターンに強制ターンエンドを発動した場合、引�
     {
       "armdozer": {
         "battery": 3,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 2,
           "type": "ForceTurnEnd",

--- a/test/effect/burst/__snapshots__/ineffective.test.ts.snap
+++ b/test/effect/burst/__snapshots__/ineffective.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`効果無効が正しく適用できる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`効果無効が正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -60,6 +61,7 @@ exports[`効果無効が正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 3,
           "type": "Ineffective",

--- a/test/effect/burst/__snapshots__/lightning-barrier.test.ts.snap
+++ b/test/effect/burst/__snapshots__/lightning-barrier.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`電撃バリアバーストの適用が正しくできる 1`] = `
 {
@@ -17,6 +17,7 @@ exports[`電撃バリアバーストの適用が正しくできる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -46,6 +47,7 @@ exports[`電撃バリアバーストの適用が正しくできる 1`] = `
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "damage": 1000,
           "duration": 2,

--- a/test/effect/burst/__snapshots__/recover-battery.test.ts.snap
+++ b/test/effect/burst/__snapshots__/recover-battery.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バースト効果バッテリー回復が正しく適用される 1`] = `
 {
@@ -16,6 +16,7 @@ exports[`バースト効果バッテリー回復が正しく適用される 1`] 
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -45,6 +46,7 @@ exports[`バースト効果バッテリー回復が正しく適用される 1`] 
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/continous-active/__snapshots__/continuous-active.test.ts.snap
+++ b/test/effect/continous-active/__snapshots__/continuous-active.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BatteryRecoverSkip、TurnStartBatteryCorrectは取り除かれる 1`] = `
 {
@@ -12,6 +12,7 @@ exports[`BatteryRecoverSkip、TurnStartBatteryCorrectは取り除かれる 1`] =
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -48,6 +49,7 @@ exports[`BatteryRecoverSkip、TurnStartBatteryCorrectは取り除かれる 1`] =
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -105,6 +107,7 @@ exports[`アクティブプレイヤー継続が正しく処理できる 1`] = `
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -141,6 +144,7 @@ exports[`アクティブプレイヤー継続が正しく処理できる 1`] = `
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/input-command/__snapshots__/input-command.test.ts.snap
+++ b/test/effect/input-command/__snapshots__/input-command.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`プレイヤーの状況に応じて、選択可能なコマンドがセットされる 1`] = `
 {
@@ -73,6 +73,7 @@ exports[`プレイヤーの状況に応じて、選択可能なコマンドが�
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -102,6 +103,7 @@ exports[`プレイヤーの状況に応じて、選択可能なコマンドが�
     {
       "armdozer": {
         "battery": 3,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -176,6 +178,7 @@ exports[`効果適用フロー後のコマンド入力フェイズ効果が正�
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -205,6 +208,7 @@ exports[`効果適用フロー後のコマンド入力フェイズ効果が正�
     {
       "armdozer": {
         "battery": 3,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/pilot-skill/__snapshots__/battery-enhancement-skill.test.ts.snap
+++ b/test/effect/pilot-skill/__snapshots__/battery-enhancement-skill.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バッテリー増強スキルが正しく発動できる 1`] = `
 {
@@ -16,6 +16,7 @@ exports[`バッテリー増強スキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -45,6 +46,7 @@ exports[`バッテリー増強スキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/pilot-skill/__snapshots__/battety-boost.test.ts.snap
+++ b/test/effect/pilot-skill/__snapshots__/battety-boost.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バッテリーブーストスキルを正しく適用できる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`バッテリーブーストスキルを正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -67,6 +68,7 @@ exports[`バッテリーブーストスキルを正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/pilot-skill/__snapshots__/buff-power-skill.test.ts.snap
+++ b/test/effect/pilot-skill/__snapshots__/buff-power-skill.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`攻撃バフスキルが正しく発動できる 1`] = `
 {
@@ -16,6 +16,7 @@ exports[`攻撃バフスキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -45,6 +46,7 @@ exports[`攻撃バフスキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/pilot-skill/__snapshots__/damage-halved-skill.test.ts.snap
+++ b/test/effect/pilot-skill/__snapshots__/damage-halved-skill.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ダメージ半減スキルが正しく発動できる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`ダメージ半減スキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`ダメージ半減スキルが正しく発動できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/pilot-skill/__snapshots__/recover-battery-skill.test.ts.snap
+++ b/test/effect/pilot-skill/__snapshots__/recover-battery-skill.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`バッテリー回復スキルを正しく適用できる 1`] = `
 {
@@ -15,6 +15,7 @@ exports[`バッテリー回復スキルを正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`バッテリー回復スキルを正しく適用できる 1`] = `
     {
       "armdozer": {
         "battery": 4,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
+++ b/test/effect/turn-change/__snapshots__/turn-change.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BatteryRecoverSkipがある場合は、バッテリー回復しない: battery-recover-skip 1`] = `
 {
@@ -12,6 +12,7 @@ exports[`BatteryRecoverSkipがある場合は、バッテリー回復しない: 
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -41,6 +42,7 @@ exports[`BatteryRecoverSkipがある場合は、バッテリー回復しない: 
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -83,6 +85,7 @@ exports[`TurnStartBatteryCorrectがある場合、回復量が補正される: t
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -112,6 +115,7 @@ exports[`TurnStartBatteryCorrectがある場合、回復量が補正される: t
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -154,6 +158,7 @@ exports[`ターン交代が正しく処理できる: has-no-effects 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -183,6 +188,7 @@ exports[`ターン交代が正しく処理できる: has-no-effects 1`] = `
     {
       "armdozer": {
         "battery": 2,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/effect/turn-change/recover-battery-on-turn-start.test.ts
+++ b/test/effect/turn-change/recover-battery-on-turn-start.test.ts
@@ -43,76 +43,157 @@ const otherEffect: CorrectPower = {
 
 /**
  * テスト用プレイヤーを生成する
- * @param battery 現在のバッテリー
- * @param effects 現在の効果
+ * @param options オプション
  * @returns 生成結果
  */
-const createPlayer = (
-  battery: number,
-  effects: ArmdozerEffect[],
-): PlayerState => ({
+const createPlayer = (options: {
+  /** 現在のバッテリー */
+  battery: number;
+  /** ターン開始時のバッテリー回復量基礎値 */
+  batteryAutoRecovery: number;
+  /** 現在の効果 */
+  effects: ArmdozerEffect[];
+}): PlayerState => ({
   ...EMPTY_PLAYER_STATE,
   playerId: "player1",
   armdozer: {
     ...EMPTY_ARMDOZER_STATE,
-    battery,
+    ...options,
     maxBattery: 5,
-    effects,
   },
 });
 
-test("ターン開始時にバッテリーが3回復する", () => {
-  const player = createPlayer(1, []);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 4,
-    recoverBattery: 3,
-  });
-});
+describe("recoverBatteryOnTurnStart", () => {
+  describe("batteryAutoRecoveryのテスト", () => {
+    test("batteryA∏∏utoRecovery=3: ターン開始時にバッテリーが3回復する", () => {
+      const player = createPlayer({
+        battery: 1,
+        batteryAutoRecovery: 3,
+        effects: [],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 4,
+        recoverBattery: 3,
+      });
+    });
 
-test("バッテリー最大値以上にはならない", () => {
-  const player = createPlayer(4, []);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 5,
-    recoverBattery: 3,
-  });
-});
+    test("batteryAutoRecovery=2: ターン開始時にバッテリーが2回復する", () => {
+      const player = createPlayer({
+        battery: 1,
+        batteryAutoRecovery: 2,
+        effects: [],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 3,
+        recoverBattery: 2,
+      });
+    });
 
-test("BatteryRecoverSkipが適用されている場合、ターン開始時のバッテリー回復はなし", () => {
-  const player = createPlayer(1, [batteryRecoverSkip]);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 1,
-    recoverBattery: 0,
-  });
-});
+    test("batteryAutoRecovery=5: バッテリー最大値以上にはならない", () => {
+      const player = createPlayer({
+        battery: 4,
+        batteryAutoRecovery: 5,
+        effects: [],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 5,
+        recoverBattery: 5,
+      });
+    });
 
-test("TurnStartBatteryCorrectが適用されている、ターン開始時回復バッテリーが補正される", () => {
-  const player = createPlayer(1, [createTurnStartBatteryCorrect(1)]);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 5,
-    recoverBattery: 4,
+    test("batteryAutoRecovery=0: ターン開始時にバッテリーが回復しない", () => {
+      const player = createPlayer({
+        battery: 2,
+        batteryAutoRecovery: 0,
+        effects: [],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 2,
+        recoverBattery: 0,
+      });
+    });
   });
-});
 
-test("TurnStartBatteryCorrectが複数適用されている場合、バッテリー補正はその合計値となる", () => {
-  const player = createPlayer(0, [
-    createTurnStartBatteryCorrect(1),
-    otherEffect,
-    otherEffect,
-    createTurnStartBatteryCorrect(1),
-  ]);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 5,
-    recoverBattery: 5,
+  describe("BatteryRecoverSkipのテスト", () => {
+    test("BatteryRecoverSkipが適用されている場合、ターン開始時のバッテリー回復はなし", () => {
+      const player = createPlayer({
+        battery: 1,
+        batteryAutoRecovery: 3,
+        effects: [batteryRecoverSkip],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 1,
+        recoverBattery: 0,
+      });
+    });
+
+    test("batteryAutoRecovery=5 かつ BatteryRecoverSkipが適用されている場合も回復なし", () => {
+      const player = createPlayer({
+        battery: 2,
+        batteryAutoRecovery: 5,
+        effects: [batteryRecoverSkip],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 2,
+        recoverBattery: 0,
+      });
+    });
   });
-});
 
-test("BatteryRecoverSkip、TurnStartBatteryCorrectが同時適用されている場合、ターン開始時のバッテリー回復はなし", () => {
-  const player = createPlayer(1, [
-    batteryRecoverSkip,
-    createTurnStartBatteryCorrect(1),
-  ]);
-  expect(recoverBatteryOnTurnStart(player)).toEqual({
-    battery: 1,
-    recoverBattery: 0,
+  describe("TurnStartBatteryCorrectのテスト", () => {
+    test("TurnStartBatteryCorrectが適用されているとき、回復量が補正される", () => {
+      const player = createPlayer({
+        battery: 1,
+        batteryAutoRecovery: 3,
+        effects: [createTurnStartBatteryCorrect(1)],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 5,
+        recoverBattery: 4,
+      });
+    });
+
+    test("batteryAutoRecovery=2, TurnStartBatteryCorrect=2 の場合、合計4回復", () => {
+      const player = createPlayer({
+        battery: 0,
+        batteryAutoRecovery: 2,
+        effects: [createTurnStartBatteryCorrect(2)],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 4,
+        recoverBattery: 4,
+      });
+    });
+
+    test("TurnStartBatteryCorrectが複数適用されている場合、バッテリー補正はその合計値となる", () => {
+      const player = createPlayer({
+        battery: 0,
+        batteryAutoRecovery: 3,
+        effects: [
+          createTurnStartBatteryCorrect(1),
+          otherEffect,
+          otherEffect,
+          createTurnStartBatteryCorrect(1),
+        ],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 5,
+        recoverBattery: 5,
+      });
+    });
+  });
+
+  describe("BatteryRecoverSkipとTurnStartBatteryCorrectの同時適用", () => {
+    test("BatteryRecoverSkip、TurnStartBatteryCorrectが同時適用されている場合、ターン開始時のバッテリー回復はなし", () => {
+      const player = createPlayer({
+        battery: 1,
+        batteryAutoRecovery: 3,
+        effects: [batteryRecoverSkip, createTurnStartBatteryCorrect(1)],
+      });
+      expect(recoverBatteryOnTurnStart(player)).toEqual({
+        battery: 1,
+        recoverBattery: 0,
+      });
+    });
   });
 });

--- a/test/effect/update-remaining-turn/__snapshots__/update-remaining-turn.test.ts.snap
+++ b/test/effect/update-remaining-turn/__snapshots__/update-remaining-turn.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`効果継続ターン更新が正しく処理される 1`] = `
 {
@@ -32,6 +32,7 @@ exports[`効果継続ターン更新が正しく処理される 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,
@@ -75,6 +76,7 @@ exports[`効果継続ターン更新が正しく処理される 1`] = `
     {
       "armdozer": {
         "battery": 5,
+        "batteryAutoRecovery": 3,
         "burst": {
           "recoverBattery": 5,
           "turnStartBatteryCorrect": 1,

--- a/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
+++ b/test/game/__snapshots__/gbraver-burst-core.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`初期状態を正しく作ることができる: initial-state 1`] = `
 [
@@ -11,6 +11,7 @@ exports[`初期状態を正しく作ることができる: initial-state 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -40,6 +41,7 @@ exports[`初期状態を正しく作ることができる: initial-state 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -151,6 +153,7 @@ exports[`初期状態を正しく作ることができる: initial-state 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -180,6 +183,7 @@ exports[`初期状態を正しく作ることができる: initial-state 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -227,6 +231,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -256,6 +261,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -298,6 +304,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -327,6 +334,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -368,6 +376,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -397,6 +406,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -435,6 +445,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -464,6 +475,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -503,6 +515,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -532,6 +545,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -635,6 +649,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -664,6 +679,7 @@ exports[`正しくゲームを進めることができる: progress 1`] = `
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/__snapshots__/progress.test.ts.snap
+++ b/test/game/progress/__snapshots__/progress.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`それ以外の場合は効果適用フローを進める: effect-activation-flow 1`] = `
 [
@@ -17,6 +17,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -46,6 +47,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -96,6 +98,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -125,6 +128,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -238,6 +242,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -267,6 +272,7 @@ exports[`それ以外の場合は効果適用フローを進める: effect-activ
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -322,6 +328,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -351,6 +358,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -394,6 +402,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -423,6 +432,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -465,6 +475,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -494,6 +505,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -532,6 +544,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -561,6 +574,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -600,6 +614,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -629,6 +644,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -736,6 +752,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -765,6 +782,7 @@ exports[`両方のプレイヤーがバッテリーコマンドを出した場�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/battle-flow.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] = `
 [
@@ -16,6 +16,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -45,6 +46,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -98,6 +100,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -127,6 +130,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -178,6 +182,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -207,6 +212,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -257,6 +263,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -286,6 +293,7 @@ exports[`ダメージ反射でHPが0になった場合は引き分け: draw 1`] 
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -343,6 +351,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -396,6 +405,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -471,6 +481,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -524,6 +535,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -598,6 +610,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -651,6 +664,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -797,6 +811,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -826,6 +841,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -865,6 +881,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -894,6 +911,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -993,6 +1011,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1022,6 +1041,7 @@ exports[`互いに効果無視が適用されている場合、すべての効�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1069,6 +1089,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1098,6 +1119,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1141,6 +1163,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1170,6 +1193,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1212,6 +1236,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1241,6 +1266,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1279,6 +1305,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1308,6 +1335,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1347,6 +1375,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1376,6 +1405,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1475,6 +1505,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1504,6 +1535,7 @@ exports[`戦闘したが、相手を倒しきれなかったのでゲーム続�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1551,6 +1583,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1580,6 +1613,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1623,6 +1657,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1652,6 +1687,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1693,6 +1729,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1722,6 +1759,7 @@ exports[`攻撃で防御側のHPを0以下にした場合、ゲームが終了�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1769,6 +1807,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1822,6 +1861,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1890,6 +1930,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1943,6 +1984,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2009,6 +2051,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2062,6 +2105,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2129,6 +2173,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2182,6 +2227,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2248,6 +2294,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2301,6 +2348,7 @@ exports[`攻撃側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2373,6 +2421,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2419,6 +2468,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2494,6 +2544,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2540,6 +2591,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2613,6 +2665,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 2,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -2659,6 +2712,7 @@ exports[`防御側に効果無視が適用されている場合、すべての�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/game-continue-flow.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ゲーム継続フロー（アクティブプレイヤー継続）を正しく処理することができる: continuous-active 1`] = `
 [
@@ -12,6 +12,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -48,6 +49,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -87,6 +89,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -116,6 +119,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -219,6 +223,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 3,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -248,6 +253,7 @@ exports[`ゲーム継続フロー（アクティブプレイヤー継続）を�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -291,6 +297,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 1,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -320,6 +327,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -359,6 +367,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -388,6 +397,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -495,6 +505,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 4,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -524,6 +535,7 @@ exports[`ゲーム継続フロー（ターン交代）を正しく処理する�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/battle-flow/__snapshots__/reflect-flow.test.ts.snap
+++ b/test/game/progress/battle-flow/__snapshots__/reflect-flow.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ダメージ反射が正しく適用される: single-reflect 1`] = `
 [
@@ -15,6 +15,7 @@ exports[`ダメージ反射が正しく適用される: single-reflect 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -44,6 +45,7 @@ exports[`ダメージ反射が正しく適用される: single-reflect 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -100,6 +102,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -129,6 +132,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -198,6 +202,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -227,6 +232,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -296,6 +302,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -325,6 +332,7 @@ exports[`ダメージ反射の重ね掛けも正しく処理される: multi-ref
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/effect-activation-flow/__snapshots__/effect-activation-flow.test.ts.snap
+++ b/test/game/progress/effect-activation-flow/__snapshots__/effect-activation-flow.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`攻撃側、防御側の両方で効果を発動した場合、両方の効果を発動してフローが進む 1`] = `
 [
@@ -17,6 +17,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -46,6 +47,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -96,6 +98,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -125,6 +128,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -238,6 +242,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -267,6 +272,7 @@ exports[`攻撃側、防御側の両方で効果を発動した場合、両方�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -322,6 +328,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -351,6 +358,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -388,6 +396,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -417,6 +426,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -524,6 +534,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -553,6 +564,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -599,6 +611,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -628,6 +641,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -665,6 +679,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -694,6 +709,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -801,6 +817,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -830,6 +847,7 @@ exports[`攻撃側が強制ターン終了を発動した場合、防御側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -877,6 +895,7 @@ exports[`攻撃側だけが効果発動した場合、防御側は何もせず�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -906,6 +925,7 @@ exports[`攻撃側だけが効果発動した場合、防御側は何もせず�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -994,6 +1014,7 @@ exports[`攻撃側だけが効果発動した場合、防御側は何もせず�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1023,6 +1044,7 @@ exports[`攻撃側だけが効果発動した場合、防御側は何もせず�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1078,6 +1100,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1106,6 +1129,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1144,6 +1168,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1172,6 +1197,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1280,6 +1306,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1308,6 +1335,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側が�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1356,6 +1384,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1384,6 +1413,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1434,6 +1464,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1462,6 +1493,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1508,6 +1540,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1536,6 +1569,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1649,6 +1683,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 2,
             "type": "ForceTurnEnd",
@@ -1677,6 +1712,7 @@ exports[`防御側が強制ターン終了を発動した場合、攻撃側の�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1732,6 +1768,7 @@ exports[`防御側だけが効果発動した場合、攻撃側はなにもせ�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1761,6 +1798,7 @@ exports[`防御側だけが効果発動した場合、攻撃側はなにもせ�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1841,6 +1879,7 @@ exports[`防御側だけが効果発動した場合、攻撃側はなにもせ�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -1870,6 +1909,7 @@ exports[`防御側だけが効果発動した場合、攻撃側はなにもせ�
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/progress/effect-activation-flow/__snapshots__/post-force-turn-end-flow.test.ts.snap
+++ b/test/game/progress/effect-activation-flow/__snapshots__/post-force-turn-end-flow.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`強制ターンエンド発動後には、UpdateRemainingTurn、InputCommandが実行される 1`] = `
 [
@@ -25,6 +25,7 @@ exports[`強制ターンエンド発動後には、UpdateRemainingTurn、InputCo
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -54,6 +55,7 @@ exports[`強制ターンエンド発動後には、UpdateRemainingTurn、InputCo
       {
         "armdozer": {
           "battery": 1,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -157,6 +159,7 @@ exports[`強制ターンエンド発動後には、UpdateRemainingTurn、InputCo
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -186,6 +189,7 @@ exports[`強制ターンエンド発動後には、UpdateRemainingTurn、InputCo
       {
         "armdozer": {
           "battery": 1,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,

--- a/test/game/start/__snapshots__/start.test.ts.snap
+++ b/test/game/start/__snapshots__/start.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ゲームを正しく開始できる 1`] = `
 [
@@ -11,6 +11,7 @@ exports[`ゲームを正しく開始できる 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -40,6 +41,7 @@ exports[`ゲームを正しく開始できる 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -151,6 +153,7 @@ exports[`ゲームを正しく開始できる 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,
@@ -180,6 +183,7 @@ exports[`ゲームを正しく開始できる 1`] = `
       {
         "armdozer": {
           "battery": 5,
+          "batteryAutoRecovery": 3,
           "burst": {
             "recoverBattery": 5,
             "turnStartBatteryCorrect": 1,


### PR DESCRIPTION
This pull request introduces a new `batteryAutoRecovery` property to the `Armdozer` type and updates related logic and tests to incorporate this property. The most significant changes include replacing the hardcoded battery recovery value with the new property, modifying the `Armdozer` schema and type definition, and updating snapshots to reflect the new property.

### Feature Addition: `batteryAutoRecovery` Property

* [`src/player/armdozer.ts`](diffhunk://#diff-a68c50f2cc3aad4c0584fc933713419b64ee1e993ddd4aafd356a8f0ff9172deR24-R25): Added `batteryAutoRecovery` to the `Armdozer` type definition and schema to define automatic battery recovery for each `Armdozer`. [[1]](diffhunk://#diff-a68c50f2cc3aad4c0584fc933713419b64ee1e993ddd4aafd356a8f0ff9172deR24-R25) [[2]](diffhunk://#diff-a68c50f2cc3aad4c0584fc933713419b64ee1e993ddd4aafd356a8f0ff9172deR43)
* [`src/master/armdozers/*.ts`](diffhunk://#diff-fa9bc5c8b012210d94dd2a5f6463b6c23e098f7b8aef16a200185e3dbd7196cdR18): Updated all `Armdozer` definitions to include a default value of `batteryAutoRecovery: 3`. [[1]](diffhunk://#diff-fa9bc5c8b012210d94dd2a5f6463b6c23e098f7b8aef16a200185e3dbd7196cdR18) [[2]](diffhunk://#diff-5aeecda7b0d49f8c6565145bb464124076213e21ac65c5eeb01d35723b012d96R10) [[3]](diffhunk://#diff-cd248291d774f3845af83fa3787d17d9485b92822c06af49747e7e9177029d5bR10) [[4]](diffhunk://#diff-4f9a4990b739744d9ec4f20c1dd86581ad03e510edc6c0d1ad4d0313460cfbe1R10) [[5]](diffhunk://#diff-73b00e1b196c359ddfa10458ecfc8234cbbda10c8ddb38d726f9f76581f7cea1R10) [[6]](diffhunk://#diff-d6c6b8c1fa7c8ae094e5f188fa4fa3037b19f315aefde94e1c3ad1df9331b9e2R10) [[7]](diffhunk://#diff-c5d7fb87a7d1724113dd6276cb5755ea9e8987a1b3c9b3c50536986786e28f7eR10) [[8]](diffhunk://#diff-5fdd9e49de6665a0a301bd94e0e4d04ea13c80e6178b407c0e401a1bf69ad973R10)

### Logic Update: Battery Recovery Calculation

* [`src/effect/turn-change/recover-battery-on-turn-start.ts`](diffhunk://#diff-567c11cf03d77f5623f8c3cd1a39077f96e6e85b9fd2f39133d24e89dd56327dL4-L6): Replaced the hardcoded `BASIC_BATTERY_RECOVER` constant with the `batteryAutoRecovery` property from the `Armdozer` object in the battery recovery calculation logic. [[1]](diffhunk://#diff-567c11cf03d77f5623f8c3cd1a39077f96e6e85b9fd2f39133d24e89dd56327dL4-L6) [[2]](diffhunk://#diff-567c11cf03d77f5623f8c3cd1a39077f96e6e85b9fd2f39133d24e89dd56327dL34-R31)

### Test Updates: Snapshot Adjustments

* [`test/effect/burst/__snapshots__/*.test.ts.snap`](diffhunk://#diff-c8bbb46becc73a785058a0856a863e7b5de4d74acae6f644c21ab71c4407ac7cR19): Updated snapshots across multiple test files to include the new `batteryAutoRecovery` property in the `Armdozer` objects. [[1]](diffhunk://#diff-c8bbb46becc73a785058a0856a863e7b5de4d74acae6f644c21ab71c4407ac7cR19) [[2]](diffhunk://#diff-35c1c45ba1789139672fa9c7e36aefe4791216c2498202adbf73ff28a91f9e89R19) [[3]](diffhunk://#diff-039995698f355c07a38512a4b265e8a8c8067ff9cab6ea56bababedad0d65e10R20) [[4]](diffhunk://#diff-a89b11fc41d6366efa9eab7b0406e8ae3435d57b43f4e7531adce1ebbe5db16aR18) [[5]](diffhunk://#diff-334950790b58b652ef034ce3cd23496fb56e51b75310c01d395235c0876f402dR18) [[6]](diffhunk://#diff-00b1eeb35d13f87b02d7262f23ad6c19def63a68a150f43a4437fd5907418e25R18) [[7]](diffhunk://#diff-97e37e7e333c0a1550598fe7b7d5538c8abea48135b7c43fb2069c13e22ebcb6R18) [[8]](diffhunk://#diff-a543fe482d6ff4dd028d7bfb533cfa8f580037cb7b9eeee6d6b881e00e17f4d0R20) [[9]](diffhunk://#diff-dd43f25b2ba00a1a68c64291bbf1461dc1994b5776120af40faeb81180303ac1R19) [[10]](diffhunk://#diff-a8c2776970ea51617054b2883d877aa6bb08bd46a817eafdb4f17664bf88e2abL1-R1)

### Documentation Update

* Updated snapshot version comments in test files to reference the current Jest documentation URL. [[1]](diffhunk://#diff-c8bbb46becc73a785058a0856a863e7b5de4d74acae6f644c21ab71c4407ac7cL1-R1) [[2]](diffhunk://#diff-35c1c45ba1789139672fa9c7e36aefe4791216c2498202adbf73ff28a91f9e89L1-R1) [[3]](diffhunk://#diff-039995698f355c07a38512a4b265e8a8c8067ff9cab6ea56bababedad0d65e10L1-R1) [[4]](diffhunk://#diff-a89b11fc41d6366efa9eab7b0406e8ae3435d57b43f4e7531adce1ebbe5db16aL1-R1) [[5]](diffhunk://#diff-334950790b58b652ef034ce3cd23496fb56e51b75310c01d395235c0876f402dL1-R1) [[6]](diffhunk://#diff-00b1eeb35d13f87b02d7262f23ad6c19def63a68a150f43a4437fd5907418e25L1-R1) [[7]](diffhunk://#diff-97e37e7e333c0a1550598fe7b7d5538c8abea48135b7c43fb2069c13e22ebcb6L1-R1) [[8]](diffhunk://#diff-a543fe482d6ff4dd028d7bfb533cfa8f580037cb7b9eeee6d6b881e00e17f4d0L1-R1) [[9]](diffhunk://#diff-dd43f25b2ba00a1a68c64291bbf1461dc1994b5776120af40faeb81180303ac1L1-R1) [[10]](diffhunk://#diff-a8c2776970ea51617054b2883d877aa6bb08bd46a817eafdb4f17664bf88e2abL1-R1)