### PR TITLE
feat: update version to 1.39.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.38.1",
+      "version": "1.39.0",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",


### PR DESCRIPTION
This pull request updates the version of the `gbraver-burst-core` package. The version has been incremented from `1.38.1` to `1.39.0` to reflect changes or improvements made to the package.