### PR TITLE
Feature/remove src index omport

### DIFF
--- a/.dependency-cruiser.mjs
+++ b/.dependency-cruiser.mjs
@@ -3,6 +3,13 @@
 export default {
   forbidden: [
     {
+      name: "no-import-src-index",
+      comment: "src/index.tsはnpm利用者専用。プロダクト・テストコードからimport禁止。",
+      severity: "error",
+      from: { pathNot: "^src/index\\.ts$" },
+      to: { path: "^src/index\\.ts$" },
+    },
+    {
       name: "no-circular",
       severity: "error",
       comment:

--- a/.dependency-cruiser.mjs
+++ b/.dependency-cruiser.mjs
@@ -4,7 +4,8 @@ export default {
   forbidden: [
     {
       name: "no-import-src-index",
-      comment: "src/index.tsはnpm利用者専用。プロダクト・テストコードからimport禁止。",
+      comment:
+        "src/index.tsはnpm利用者専用。プロダクト・テストコードからimport禁止。",
       severity: "error",
       from: { pathNot: "^src/index\\.ts$" },
       to: { path: "^src/index\\.ts$" },

--- a/test/command/battery-command-schema.test.ts
+++ b/test/command/battery-command-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryCommand, BatteryCommandSchema } from "../../src";
+import {
+  BatteryCommand,
+  BatteryCommandSchema,
+} from "../../src/command/battery";
 
 test("バッテリーコマンドを正しくパースできる", () => {
   const data: BatteryCommand = { type: "BATTERY_COMMAND", battery: 4 };

--- a/test/command/burtst-command-schema.test.ts
+++ b/test/command/burtst-command-schema.test.ts
@@ -1,4 +1,4 @@
-import { BurstCommand, BurstCommandSchema } from "../../src";
+import { BurstCommand, BurstCommandSchema } from "../../src/command/burst";
 
 test("バーストコマンドをパースできる", () => {
   const data: BurstCommand = { type: "BURST_COMMAND" };

--- a/test/command/command-schema.test.ts
+++ b/test/command/command-schema.test.ts
@@ -1,4 +1,4 @@
-import { Command, CommandSchema } from "../../src";
+import { Command, CommandSchema } from "../../src/command/command";
 
 /** 有効なCommand */
 const commands: Command[] = [

--- a/test/command/pilot-skill-command-schema.test.ts
+++ b/test/command/pilot-skill-command-schema.test.ts
@@ -1,4 +1,7 @@
-import { PilotSkillCommand, PilotSkillCommandSchema } from "../../src";
+import {
+  PilotSkillCommand,
+  PilotSkillCommandSchema,
+} from "../../src/command/pilot-skill";
 
 test("パイロットスキルコマンドをパースできる", () => {
   const data: PilotSkillCommand = { type: "PILOT_SKILL_COMMAND" };

--- a/test/effect/battery-declaration/battery-declaration-schema.test.ts
+++ b/test/effect/battery-declaration/battery-declaration-schema.test.ts
@@ -1,4 +1,4 @@
-import { BatteryDeclarationSchema } from "../../../src/effect/battery-declaration/battery-declaration.ts";
+import { BatteryDeclarationSchema } from "../../../src/effect/battery-declaration/battery-declaration";
 import { validBatteryDeclaration } from "./valid-battery-declaration";
 
 test("BatteryDeclarationはパースできる", () => {

--- a/test/effect/battery-declaration/battery-declaration-schema.test.ts
+++ b/test/effect/battery-declaration/battery-declaration-schema.test.ts
@@ -1,4 +1,4 @@
-import { BatteryDeclarationSchema } from "../../../src";
+import { BatteryDeclarationSchema } from "../../../src/effect/battery-declaration/battery-declaration.ts";
 import { validBatteryDeclaration } from "./valid-battery-declaration";
 
 test("BatteryDeclarationはパースできる", () => {

--- a/test/effect/battery-declaration/battery-declaration.test.ts
+++ b/test/effect/battery-declaration/battery-declaration.test.ts
@@ -1,13 +1,11 @@
-import {
-  BatteryCommand,
-  GameState,
-  PlayerCommandX,
-  PlayerState,
-} from "../../../src";
+import { BatteryCommand } from "../../../src/command/battery";
 import { batteryDeclaration } from "../../../src/effect/battery-declaration";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerCommandX } from "../../../src/game/command/player-command";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 test("バッテリー宣言が正しく処理される", () => {
   const attacker: PlayerState = {

--- a/test/effect/battery-declaration/valid-battery-declaration.ts
+++ b/test/effect/battery-declaration/valid-battery-declaration.ts
@@ -1,4 +1,4 @@
-import { BatteryDeclaration } from "../../../src";
+import { BatteryDeclaration } from "../../../src/effect/battery-declaration/battery-declaration";
 
 /** 有効なBatteryDeclaration */
 export const validBatteryDeclaration: BatteryDeclaration = {

--- a/test/effect/battle/battle-schema.test.ts
+++ b/test/effect/battle/battle-schema.test.ts
@@ -1,4 +1,4 @@
-import { BattleSchema } from "../../../src";
+import { BattleSchema } from "../../../src/effect/battle/battle";
 import { validBattle } from "./valid-battle";
 
 test("Battleはパースできる", () => {

--- a/test/effect/battle/result/battle-results-schema.test.ts
+++ b/test/effect/battle/result/battle-results-schema.test.ts
@@ -1,4 +1,7 @@
-import { BattleResult, BattleResultSchema } from "../../../../src";
+import {
+  BattleResult,
+  BattleResultSchema,
+} from "../../../../src/effect/battle/result/battle-result";
 
 /** 有効なBattleResult */
 const battleResults: BattleResult[] = [

--- a/test/effect/battle/result/critical-hit-schema.test.ts
+++ b/test/effect/battle/result/critical-hit-schema.test.ts
@@ -1,4 +1,7 @@
-import { CriticalHit, CriticalHitSchema } from "../../../../src";
+import {
+  CriticalHit,
+  CriticalHitSchema,
+} from "../../../../src/effect/battle/result/critical-hit";
 
 /** 有効なCriticalHit */
 const criticalHit: CriticalHit = {

--- a/test/effect/battle/result/feint-schema.test.ts
+++ b/test/effect/battle/result/feint-schema.test.ts
@@ -1,4 +1,4 @@
-import { Feint, FeintSchema } from "../../../../src";
+import { Feint, FeintSchema } from "../../../../src/effect/battle/result/feint";
 
 /** 有効なFeint */
 const feint: Feint = {

--- a/test/effect/battle/result/guard-schema.test.ts
+++ b/test/effect/battle/result/guard-schema.test.ts
@@ -1,4 +1,4 @@
-import { Guard, GuardSchema } from "../../../../src";
+import { Guard, GuardSchema } from "../../../../src/effect/battle/result/guard";
 
 /** 有効なGuard */
 const guard: Guard = {

--- a/test/effect/battle/result/guard.test.ts
+++ b/test/effect/battle/result/guard.test.ts
@@ -1,4 +1,3 @@
-import { ArmdozerEffect } from "../../../../src";
 import { guard } from "../../../../src/effect/battle/result/guard";
 import {
   EMPTY_CORRECT_POWER,
@@ -6,6 +5,7 @@ import {
 } from "../../../../src/empty/amrdozer-effect";
 import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
 import { PlayerState } from "../../../../src/state/player-state";
 
 /** 攻撃側のパラメータ */

--- a/test/effect/battle/result/miss-schema.test.ts
+++ b/test/effect/battle/result/miss-schema.test.ts
@@ -1,4 +1,4 @@
-import { Miss, MissSchema } from "../../../../src";
+import { Miss, MissSchema } from "../../../../src/effect/battle/result/miss";
 
 /** 有効なMiss */
 const miss: Miss = {

--- a/test/effect/battle/result/normal-hit-schema.test.ts
+++ b/test/effect/battle/result/normal-hit-schema.test.ts
@@ -1,4 +1,7 @@
-import { NormalHit, NormalHitSchema } from "../../../../src";
+import {
+  NormalHit,
+  NormalHitSchema,
+} from "../../../../src/effect/battle/result/normal-hit";
 
 /** 有効なNormalHit */
 const normalHit: NormalHit = {

--- a/test/effect/battle/result/normal-hit.test.ts
+++ b/test/effect/battle/result/normal-hit.test.ts
@@ -1,12 +1,9 @@
-import { ArmdozerEffect } from "../../../../src";
 import { normalHit } from "../../../../src/effect/battle/result/normal-hit";
-import {
-  EMPTY_CORRECT_POWER,
-  EMPTY_DAMAGE_HALVED,
-} from "../../../../src/empty/amrdozer-effect";
+import { EMPTY_CORRECT_POWER, EMPTY_DAMAGE_HALVED } from "../../../../src/empty/amrdozer-effect";
 import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
-import type { PlayerState } from "../../../../src/state/player-state";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** 攻撃プレイヤーのパラメータ */
 type AttackerParams = {

--- a/test/effect/battle/result/normal-hit.test.ts
+++ b/test/effect/battle/result/normal-hit.test.ts
@@ -1,5 +1,8 @@
 import { normalHit } from "../../../../src/effect/battle/result/normal-hit";
-import { EMPTY_CORRECT_POWER, EMPTY_DAMAGE_HALVED } from "../../../../src/empty/amrdozer-effect";
+import {
+  EMPTY_CORRECT_POWER,
+  EMPTY_DAMAGE_HALVED,
+} from "../../../../src/empty/amrdozer-effect";
 import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";

--- a/test/effect/battle/valid-battle.ts
+++ b/test/effect/battle/valid-battle.ts
@@ -1,4 +1,4 @@
-import { Battle } from "../../../src";
+import { Battle } from "../../../src/effect/battle/battle";
 
 /** 有効なBattle */
 export const validBattle: Battle = {

--- a/test/effect/burst/battery-drain.test.ts
+++ b/test/effect/burst/battery-drain.test.ts
@@ -1,7 +1,9 @@
-import { EMPTY_GAME_STATE, GameState, PlayerState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state.ts";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/battery-drain.test.ts
+++ b/test/effect/burst/battery-drain.test.ts
@@ -2,7 +2,7 @@ import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
-import { GameState } from "../../../src/state/game-state.ts";
+import { GameState } from "../../../src/state/game-state";
 import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */

--- a/test/effect/burst/battery-limit-break.test.ts
+++ b/test/effect/burst/battery-limit-break.test.ts
@@ -1,7 +1,9 @@
-import { EMPTY_GAME_STATE, GameState, PlayerState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動プレイヤー */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/buff-power.test.ts
+++ b/test/effect/burst/buff-power.test.ts
@@ -1,12 +1,10 @@
-import {
-  EMPTY_ARMDOZER_EFFECT,
-  type GameState,
-  type PlayerState,
-} from "../../../src";
 import { burst } from "../../../src/effect/burst";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/burst-effect-schema.test.ts
+++ b/test/effect/burst/burst-effect-schema.test.ts
@@ -1,4 +1,4 @@
-import { BurstEffectSchema } from "../../../src";
+import { BurstEffectSchema } from "../../../src/effect/burst/burst-effect";
 import { validBurstEffect } from "./valid-burst-effect";
 
 test("BurstEffectはパースできる", () => {

--- a/test/effect/burst/continuous-attack.test.ts
+++ b/test/effect/burst/continuous-attack.test.ts
@@ -1,7 +1,8 @@
-import type { GameState, PlayerState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/effect-clear.test.ts
+++ b/test/effect/burst/effect-clear.test.ts
@@ -1,7 +1,9 @@
-import { EMPTY_GAME_STATE, GameState, PlayerState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/force-turn-end.test.ts
+++ b/test/effect/burst/force-turn-end.test.ts
@@ -1,12 +1,10 @@
-import {
-  burst,
-  EMPTY_ARMDOZER_EFFECT,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  GameState,
-  PlayerState,
-} from "../../../src";
+import { burst } from "../../../src/effect/burst";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
+import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/ineffective.test.ts
+++ b/test/effect/burst/ineffective.test.ts
@@ -1,7 +1,9 @@
-import { EMPTY_GAME_STATE, GameState, PlayerState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/lightning-barrier.test.ts
+++ b/test/effect/burst/lightning-barrier.test.ts
@@ -1,9 +1,10 @@
-import { EMPTY_ARMDOZER_EFFECT, type GameState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
-import type { PlayerState } from "../../../src/state/player-state";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/recover-battery.test.ts
+++ b/test/effect/burst/recover-battery.test.ts
@@ -1,9 +1,9 @@
-import type { GameState } from "../../../src";
 import { burst } from "../../../src/effect/burst";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
-import type { PlayerState } from "../../../src/state/player-state";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バースト発動者 */
 const burstPlayer: PlayerState = {

--- a/test/effect/burst/valid-burst-effect.ts
+++ b/test/effect/burst/valid-burst-effect.ts
@@ -1,4 +1,4 @@
-import { BurstEffect } from "../../../src";
+import { BurstEffect } from "../../../src/effect/burst/burst-effect";
 
 /** 有効なBurstEffect */
 export const validBurstEffect: BurstEffect = {

--- a/test/effect/continous-active/can-continuous-active.test.ts
+++ b/test/effect/continous-active/can-continuous-active.test.ts
@@ -1,7 +1,7 @@
-import { PlayerState } from "../../../src";
 import { canContinuousActive } from "../../../src/effect/continuous-active";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** 連続攻撃を持つプレイヤー */
 const continuousActivePlayer: PlayerState = {

--- a/test/effect/continous-active/continuous-active.test.ts
+++ b/test/effect/continous-active/continuous-active.test.ts
@@ -1,15 +1,13 @@
-import {
-  ArmdozerEffect,
-  BatteryRecoverSkip,
-  ContinuousActivePlayer,
-  EMPTY_ARMDOZER_EFFECT,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-  TurnStartBatteryCorrect,
-} from "../../../src";
 import { continuousActive } from "../../../src/effect/continuous-active";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
+import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
+import { BatteryRecoverSkip } from "../../../src/state/armdozer-effect/battery-recover-skip";
+import { ContinuousActivePlayer } from "../../../src/state/armdozer-effect/continuous-active-player";
+import { TurnStartBatteryCorrect } from "../../../src/state/armdozer-effect/turn-start-battery-correction";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** 効果 アクティブプレイヤー継続 */
 const CONTINUOUS_ACTIVE: ContinuousActivePlayer = {

--- a/test/effect/continous-active/has-continuous-active.test.ts
+++ b/test/effect/continous-active/has-continuous-active.test.ts
@@ -1,9 +1,7 @@
-import type {
-  ArmdozerEffect,
-  ContinuousActivePlayer,
-  CorrectPower,
-} from "../../../src";
 import { hasContinuousActive } from "../../../src/effect/continuous-active/has-continuous-active";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
+import { ContinuousActivePlayer } from "../../../src/state/armdozer-effect/continuous-active-player";
+import { CorrectPower } from "../../../src/state/armdozer-effect/correct-power";
 
 const continuousActivePlayer: ContinuousActivePlayer = {
   type: "ContinuousActivePlayer",

--- a/test/effect/continous-active/remove-continuous-active.test.ts
+++ b/test/effect/continous-active/remove-continuous-active.test.ts
@@ -1,6 +1,7 @@
-import type { ArmdozerEffect, CorrectPower } from "../../../src";
 import { removeContinuousActive } from "../../../src/effect/continuous-active/remove-continuous-active";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
 import { ContinuousActivePlayer } from "../../../src/state/armdozer-effect/continuous-active-player";
+import { CorrectPower } from "../../../src/state/armdozer-effect/correct-power";
 
 const CORRECT_POWER: CorrectPower = {
   type: "CorrectPower",

--- a/test/effect/correct-power.test.ts
+++ b/test/effect/correct-power.test.ts
@@ -1,9 +1,7 @@
-import {
-  ArmdozerEffectsDisabled,
-  CorrectPower,
-  correctPower,
-  HalveCorrectPower,
-} from "../../src";
+import { correctPower } from "../../src/effect/correct-power";
+import { ArmdozerEffectsDisabled } from "../../src/state/armdozer-effect/armdozer-effects-disabled";
+import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
+import { HalveCorrectPower } from "../../src/state/armdozer-effect/halve-correct-power";
 
 /** 攻撃補正半減 */
 const halveCorrect: HalveCorrectPower = {

--- a/test/effect/corrected-battery.test.ts
+++ b/test/effect/corrected-battery.test.ts
@@ -1,5 +1,7 @@
-import { ArmdozerEffect, BatteryCommand, BatteryCorrection } from "../../src";
+import { BatteryCommand } from "../../src/command/battery";
 import { correctedBattery } from "../../src/effect/battery-correction";
+import { ArmdozerEffect } from "../../src/state/armdozer-effect";
+import { BatteryCorrection } from "../../src/state/armdozer-effect/battery-correction";
 
 /**
  * バッテリー補正を作成する

--- a/test/effect/damage-reduction.test.ts
+++ b/test/effect/damage-reduction.test.ts
@@ -1,5 +1,6 @@
-import { ArmdozerEffectsDisabled, DamageHalved } from "../../src";
 import { damageReduction } from "../../src/effect/damage-reduction";
+import { ArmdozerEffectsDisabled } from "../../src/state/armdozer-effect/armdozer-effects-disabled";
+import { DamageHalved } from "../../src/state/armdozer-effect/damage-halved";
 
 /** ダメージ半減効果 */
 const damageHalved: DamageHalved = {

--- a/test/effect/effect-schema.test.ts
+++ b/test/effect/effect-schema.test.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectSchema } from "../../src";
+import { Effect, EffectSchema } from "../../src/effect";
 import { validBatteryDeclaration } from "./battery-declaration/valid-battery-declaration";
 import { validBattle } from "./battle/valid-battle";
 import { validBurstEffect } from "./burst/valid-burst-effect";

--- a/test/effect/game-end/game-end-result-schema.test.ts
+++ b/test/effect/game-end/game-end-result-schema.test.ts
@@ -1,4 +1,7 @@
-import { GameEndResult, GameEndResultSchema } from "../../../src";
+import {
+  GameEndResult,
+  GameEndResultSchema,
+} from "../../../src/effect/game-end/game-end";
 
 /** 有効なGameEndResult */
 const gameEndResults: GameEndResult[] = [

--- a/test/effect/game-end/game-end-schema.test.ts
+++ b/test/effect/game-end/game-end-schema.test.ts
@@ -1,4 +1,4 @@
-import { GameEndSchema } from "../../../src";
+import { GameEndSchema } from "../../../src/effect/game-end/game-end";
 import { validGameEnd } from "./valid-game-end";
 
 test("GameEndはパースできる", () => {

--- a/test/effect/game-end/valid-game-end.ts
+++ b/test/effect/game-end/valid-game-end.ts
@@ -1,4 +1,4 @@
-import { GameEnd } from "../../../src";
+import { GameEnd } from "../../../src/effect/game-end/game-end";
 
 /** 有効なGameEnd */
 export const validGameEnd: GameEnd = {

--- a/test/effect/get-recover-battery.test.ts
+++ b/test/effect/get-recover-battery.test.ts
@@ -1,9 +1,7 @@
-import {
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-} from "../../src";
 import { getRecoverBattery } from "../../src/effect/get-recover-battery";
+import { EMPTY_ARMDOZER_STATE } from "../../src/empty/armdozer";
+import { EMPTY_PLAYER_STATE } from "../../src/empty/player";
+import { PlayerState } from "../../src/state/player-state";
 
 /**
  * プレイヤーステートを生成する

--- a/test/effect/has-armdozer-effects-disabled.test.ts
+++ b/test/effect/has-armdozer-effects-disabled.test.ts
@@ -1,5 +1,6 @@
-import { ArmdozerEffectsDisabled, CorrectPower } from "../../src";
 import { hasArmdozerEffectsDisabled } from "../../src/effect/has-armdozer-effects-disabled";
+import { ArmdozerEffectsDisabled } from "../../src/state/armdozer-effect/armdozer-effects-disabled";
+import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
 
 /** アームドーザ効果無効 */
 const armdozerEffectDisabled: ArmdozerEffectsDisabled = {

--- a/test/effect/has-halve-correct-power.test.ts
+++ b/test/effect/has-halve-correct-power.test.ts
@@ -1,4 +1,4 @@
-import { hasHalveCorrectPower } from "../../src";
+import { hasHalveCorrectPower } from "../../src/effect/correct-power";
 import { ArmdozerEffect } from "../../src/state/armdozer-effect";
 import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
 import { HalveCorrectPower } from "../../src/state/armdozer-effect/halve-correct-power";

--- a/test/effect/input-command/input-command-on-game-start.test.ts
+++ b/test/effect/input-command/input-command-on-game-start.test.ts
@@ -1,7 +1,8 @@
-import type { GameState, PlayerState } from "../../../src";
 import { inputCommandOnGameStart } from "../../../src/effect/input-command";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 const ATTACKER: PlayerState = {
   ...EMPTY_PLAYER_STATE,

--- a/test/effect/input-command/input-command-schema.test.ts
+++ b/test/effect/input-command/input-command-schema.test.ts
@@ -1,4 +1,4 @@
-import { InputCommandSchema } from "../../../src";
+import { InputCommandSchema } from "../../../src/effect/input-command/input-command";
 import { validInputCommand } from "./valid-input-command";
 
 test("InputCommandはパースできる", () => {

--- a/test/effect/input-command/input-command.test.ts
+++ b/test/effect/input-command/input-command.test.ts
@@ -1,8 +1,9 @@
-import { BatteryCommand, PlayerId } from "../../../src";
+import { BatteryCommand } from "../../../src/command/battery";
 import { inputCommand } from "../../../src/effect/input-command";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerId } from "../../../src/player/player";
 
 /**
  * プレイヤーを生成する

--- a/test/effect/input-command/no-choice-schema.test.ts
+++ b/test/effect/input-command/no-choice-schema.test.ts
@@ -1,4 +1,7 @@
-import { NoChoice, NoChoiceSchema } from "../../../src";
+import {
+  NoChoice,
+  NoChoiceSchema,
+} from "../../../src/effect/input-command/input-command";
 
 /** 有効なNoChoice */
 const noChoice: NoChoice = {

--- a/test/effect/input-command/selectable-battery-command.test.ts
+++ b/test/effect/input-command/selectable-battery-command.test.ts
@@ -1,6 +1,6 @@
 import { selectableBatteryCommand } from "../../../src/effect/input-command/selectable-battery-command";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
-import type { ArmdozerState } from "../../../src/state/armdozer-state";
+import { ArmdozerState } from "../../../src/state/armdozer-state";
 
 const ARMDOZER_STATE: ArmdozerState = {
   ...EMPTY_ARMDOZER_STATE,

--- a/test/effect/input-command/selectable-pilot-skill-command.test.ts
+++ b/test/effect/input-command/selectable-pilot-skill-command.test.ts
@@ -1,4 +1,4 @@
-import { PilotSkillCommand } from "../../../src";
+import { PilotSkillCommand } from "../../../src/command/pilot-skill";
 import { selectablePilotSkillCommand } from "../../../src/effect/input-command/selectable-pilot-skill-command";
 import { EMPTY_PILOT_STATE } from "../../../src/empty/pilot";
 import { PilotState } from "../../../src/state/pilot-state";

--- a/test/effect/input-command/selectable-schema.test.ts
+++ b/test/effect/input-command/selectable-schema.test.ts
@@ -1,4 +1,7 @@
-import { Selectable, SelectableSchema } from "../../../src";
+import {
+  Selectable,
+  SelectableSchema,
+} from "../../../src/effect/input-command/input-command";
 
 /** 有効なSelectable */
 const selectable: Selectable = {

--- a/test/effect/input-command/valid-input-command.ts
+++ b/test/effect/input-command/valid-input-command.ts
@@ -1,4 +1,4 @@
-import { InputCommand } from "../../../src";
+import { InputCommand } from "../../../src/effect/input-command/input-command";
 
 /** 有効なInputCommand */
 export const validInputCommand: InputCommand = {

--- a/test/effect/pilot-skill/battery-enhancement-skill.test.ts
+++ b/test/effect/pilot-skill/battery-enhancement-skill.test.ts
@@ -1,13 +1,11 @@
-import {
-  EMPTY_ARMDOZER_EFFECT,
-  type GameState,
-  type PlayerState,
-} from "../../../src";
 import { pilotSkill } from "../../../src/effect/pilot-skill";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PILOT } from "../../../src/empty/pilot";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
 import { BatteryEnhancementSkill } from "../../../src/player/pilot/battery-enhancement-skill";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** バッテリー増強スキル */
 const skill: BatteryEnhancementSkill = {

--- a/test/effect/pilot-skill/battety-boost.test.ts
+++ b/test/effect/pilot-skill/battety-boost.test.ts
@@ -1,13 +1,11 @@
-import {
-  ArmdozerEffect,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_GAME_STATE,
-  EMPTY_PILOT_STATE,
-  EMPTY_PLAYER_STATE,
-  GameState,
-  PlayerState,
-} from "../../../src";
 import { pilotSkill } from "../../../src/effect/pilot-skill";
+import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
+import { EMPTY_PILOT_STATE } from "../../../src/empty/pilot";
+import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** BatteryRecoverSkip以外の効果 */
 const effectOtherThanBatteryRecoverSkip: ArmdozerEffect = {

--- a/test/effect/pilot-skill/buff-power-skill.test.ts
+++ b/test/effect/pilot-skill/buff-power-skill.test.ts
@@ -1,13 +1,11 @@
-import {
-  BuffPowerSkill,
-  EMPTY_ARMDOZER_EFFECT,
-  type GameState,
-  type PlayerState,
-} from "../../../src";
 import { pilotSkill } from "../../../src/effect/pilot-skill";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PILOT } from "../../../src/empty/pilot";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { BuffPowerSkill } from "../../../src/player/pilot/buff-power-skill";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** スキル 攻撃バフ */
 const skill: BuffPowerSkill = {

--- a/test/effect/pilot-skill/damage-halved-skill.test.ts
+++ b/test/effect/pilot-skill/damage-halved-skill.test.ts
@@ -1,13 +1,11 @@
-import {
-  EMPTY_ARMDOZER_EFFECT,
-  type GameState,
-  type PlayerState,
-} from "../../../src";
 import { pilotSkill } from "../../../src/effect/pilot-skill";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PILOT } from "../../../src/empty/pilot";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
 import { DamageHalvedSkill } from "../../../src/player/pilot/damage-halved-skill";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** スキル ダメージ半減 */
 const skill: DamageHalvedSkill = {

--- a/test/effect/pilot-skill/pilot-skill-effect-schema.test.ts
+++ b/test/effect/pilot-skill/pilot-skill-effect-schema.test.ts
@@ -1,4 +1,4 @@
-import { PilotSkillEffectSchema } from "../../../src";
+import { PilotSkillEffectSchema } from "../../../src/effect/pilot-skill/pilot-skill-effect";
 import { validPilotSkillEffect } from "./valid-pilot-skill-effect";
 
 test("PilotSkillEffectはパースできる", () => {

--- a/test/effect/pilot-skill/recover-battery-skill.test.ts
+++ b/test/effect/pilot-skill/recover-battery-skill.test.ts
@@ -1,13 +1,11 @@
-import {
-  EMPTY_ARMDOZER_EFFECT,
-  type GameState,
-  type PlayerState,
-} from "../../../src";
 import { pilotSkill } from "../../../src/effect/pilot-skill";
+import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PILOT } from "../../../src/empty/pilot";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
 import { RecoverBatterySkill } from "../../../src/player/pilot/recover-battery-skill";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** スキル バッテリー回復 */
 const skill: RecoverBatterySkill = {

--- a/test/effect/pilot-skill/valid-pilot-skill-effect.ts
+++ b/test/effect/pilot-skill/valid-pilot-skill-effect.ts
@@ -1,4 +1,4 @@
-import { PilotSkillEffect } from "../../../src";
+import { PilotSkillEffect } from "../../../src/effect/pilot-skill/pilot-skill-effect";
 
 /** 有効なPilotSkillEffect */
 export const validPilotSkillEffect: PilotSkillEffect = {

--- a/test/effect/predicated-damage.test.ts
+++ b/test/effect/predicated-damage.test.ts
@@ -1,12 +1,10 @@
-import {
-  ArmdozerEffect,
-  CorrectPower,
-  DamageHalved,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-  predicatedDamage,
-} from "../../src";
+import { predicatedDamage } from "../../src/effect/predicated-damage";
+import { EMPTY_ARMDOZER_STATE } from "../../src/empty/armdozer";
+import { EMPTY_PLAYER_STATE } from "../../src/empty/player";
+import { ArmdozerEffect } from "../../src/state/armdozer-effect";
+import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
+import { DamageHalved } from "../../src/state/armdozer-effect/damage-halved";
+import { PlayerState } from "../../src/state/player-state";
 
 /**
  * 攻撃側プレイヤーのステートを生成する

--- a/test/effect/reflect/reflect-damage.test.ts
+++ b/test/effect/reflect/reflect-damage.test.ts
@@ -1,8 +1,8 @@
-import type { PlayerState } from "../../../src";
-import type { ReflectParam } from "../../../src/effect/reflect/reflect";
+import { ReflectParam } from "../../../src/effect/reflect/reflect";
 import { reflectDamage } from "../../../src/effect/reflect/reflect-damage";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerState } from "../../../src/state/player-state";
 
 test("反射するダメージを正しく計算できる", () => {
   const reflect: ReflectParam = {

--- a/test/effect/reflect/reflect-schema.test.ts
+++ b/test/effect/reflect/reflect-schema.test.ts
@@ -1,4 +1,4 @@
-import { ReflectSchema } from "../../../src";
+import { ReflectSchema } from "../../../src/effect/reflect/reflect";
 import { validReflect } from "./valid-reflect";
 
 test("Reflectはパースできる", () => {

--- a/test/effect/reflect/valid-reflect.ts
+++ b/test/effect/reflect/valid-reflect.ts
@@ -1,4 +1,4 @@
-import { Reflect } from "../../../src";
+import { Reflect } from "../../../src/effect/reflect/reflect";
 
 /** 有効なReflect */
 export const validReflect: Reflect = {

--- a/test/effect/remove-battery-recover-skip.test.ts
+++ b/test/effect/remove-battery-recover-skip.test.ts
@@ -1,5 +1,6 @@
-import { BatteryRecoverSkip, CorrectPower } from "../../src";
 import { removeBatteryRecoverSkip } from "../../src/effect/remove-battery-recover-skip";
+import { BatteryRecoverSkip } from "../../src/state/armdozer-effect/battery-recover-skip";
+import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
 
 /** 効果 ターン開始時バッテリー回復スキップ */
 const batteryRecoverSkip: BatteryRecoverSkip = {

--- a/test/effect/remove-turn-start-battery-correct.test.ts
+++ b/test/effect/remove-turn-start-battery-correct.test.ts
@@ -1,5 +1,6 @@
-import { CorrectPower, TurnStartBatteryCorrect } from "../../src";
 import { removeTurnStartBatteryCorrect } from "../../src/effect/remove-turn-start-battery-correct";
+import { CorrectPower } from "../../src/state/armdozer-effect/correct-power";
+import { TurnStartBatteryCorrect } from "../../src/state/armdozer-effect/turn-start-battery-correction";
 
 /** ターン開始時バッテリー回復量補正  */
 const turnStartBatteryCorrect: TurnStartBatteryCorrect = {

--- a/test/effect/right-itself/can-right-itself.test.ts
+++ b/test/effect/right-itself/can-right-itself.test.ts
@@ -1,4 +1,4 @@
-import type { Battle } from "../../../src";
+import { Battle } from "../../../src/effect/battle/battle";
 import { canRightItself } from "../../../src/effect/right-itself";
 import { EMPTY_BATTLE } from "../../../src/empty/battle";
 

--- a/test/effect/right-itself/right-itself-schema.test.ts
+++ b/test/effect/right-itself/right-itself-schema.test.ts
@@ -1,4 +1,4 @@
-import { RightItselfSchema } from "../../../src";
+import { RightItselfSchema } from "../../../src/effect/right-itself/right-itself";
 import { validRightItself } from "./valid-right-itself";
 
 test("RightItselfはパースできる", () => {

--- a/test/effect/right-itself/right-itself.test.ts
+++ b/test/effect/right-itself/right-itself.test.ts
@@ -1,7 +1,8 @@
-import { Battle, GameState } from "../../../src";
+import { Battle } from "../../../src/effect/battle/battle";
 import { rightItself } from "../../../src/effect/right-itself";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { GameState } from "../../../src/state/game-state";
 
 /** 攻撃側プレイヤー */
 const attacker = { ...EMPTY_PLAYER_STATE, playerId: "attacker" };

--- a/test/effect/right-itself/valid-right-itself.ts
+++ b/test/effect/right-itself/valid-right-itself.ts
@@ -1,4 +1,4 @@
-import { RightItself } from "../../../src";
+import { RightItself } from "../../../src/effect/right-itself/right-itself";
 
 /** 有効なRightItself */
 export const validRightItself: RightItself = {

--- a/test/effect/start-game/first-turn-player.test.ts
+++ b/test/effect/start-game/first-turn-player.test.ts
@@ -1,7 +1,7 @@
-import { PlayerId } from "../../../src";
 import { getFirstTurnPlayer } from "../../../src/effect/start-game/first-turn-payer";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerId } from "../../../src/player/player";
 import { PlayerState } from "../../../src/state/player-state";
 
 /**

--- a/test/effect/start-game/start-game-schema.test.ts
+++ b/test/effect/start-game/start-game-schema.test.ts
@@ -1,4 +1,4 @@
-import { StartGameSchema } from "../../../src";
+import { StartGameSchema } from "../../../src/effect/start-game/start-game";
 import { validStartGame } from "./valid-start-game";
 
 test("StartGameはパースできる", () => {

--- a/test/effect/start-game/valid-start-game.ts
+++ b/test/effect/start-game/valid-start-game.ts
@@ -1,4 +1,4 @@
-import { StartGame } from "../../../src";
+import { StartGame } from "../../../src/effect/start-game/start-game";
 
 /** 有効なStartGame */
 export const validStartGame: StartGame = {

--- a/test/effect/turn-change/recover-battery-on-turn-start.test.ts
+++ b/test/effect/turn-change/recover-battery-on-turn-start.test.ts
@@ -1,13 +1,11 @@
-import {
-  ArmdozerEffect,
-  BatteryRecoverSkip,
-  CorrectPower,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-  TurnStartBatteryCorrect,
-} from "../../../src";
 import { recoverBatteryOnTurnStart } from "../../../src/effect/turn-change/recover-battery-on-turn-start";
+import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
+import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
+import { BatteryRecoverSkip } from "../../../src/state/armdozer-effect/battery-recover-skip";
+import { CorrectPower } from "../../../src/state/armdozer-effect/correct-power";
+import { TurnStartBatteryCorrect } from "../../../src/state/armdozer-effect/turn-start-battery-correction";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** 効果 ターン開始時のバッテリー回復をスキップ */
 const batteryRecoverSkip: BatteryRecoverSkip = {

--- a/test/effect/turn-change/turn-change.test.ts
+++ b/test/effect/turn-change/turn-change.test.ts
@@ -1,12 +1,10 @@
-import {
-  ArmdozerEffect,
-  BatteryRecoverSkip,
-  TurnStartBatteryCorrect,
-} from "../../../src";
 import { turnChange } from "../../../src/effect/turn-change";
 import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
+import { BatteryRecoverSkip } from "../../../src/state/armdozer-effect/battery-recover-skip";
+import { TurnStartBatteryCorrect } from "../../../src/state/armdozer-effect/turn-start-battery-correction";
 import { GameState } from "../../../src/state/game-state";
 
 /** 効果 ターン開始時バッテリー回復スキップ */

--- a/test/effect/turn-change/valid-turn-change.ts
+++ b/test/effect/turn-change/valid-turn-change.ts
@@ -1,4 +1,4 @@
-import { TurnChange } from "../../../src";
+import { TurnChange } from "../../../src/effect/turn-change/turn-change";
 
 /** 有効なTurnChange */
 export const validTurnChange: TurnChange = {

--- a/test/effect/update-remaining-turn/end-armdozer-effect-schema.test.ts
+++ b/test/effect/update-remaining-turn/end-armdozer-effect-schema.test.ts
@@ -1,4 +1,4 @@
-import { EndArmdozerEffect, EndArmdozerEffectSchema } from "../../../src";
+import { EndArmdozerEffect, EndArmdozerEffectSchema } from "../../../src/effect/update-remaining-turn/update-remaining-turn";
 
 /** 有効なEndArmdozerEffect */
 const endArmdozerEffect: EndArmdozerEffect = {

--- a/test/effect/update-remaining-turn/end-armdozer-effect-schema.test.ts
+++ b/test/effect/update-remaining-turn/end-armdozer-effect-schema.test.ts
@@ -1,4 +1,7 @@
-import { EndArmdozerEffect, EndArmdozerEffectSchema } from "../../../src/effect/update-remaining-turn/update-remaining-turn";
+import {
+  EndArmdozerEffect,
+  EndArmdozerEffectSchema,
+} from "../../../src/effect/update-remaining-turn/update-remaining-turn";
 
 /** 有効なEndArmdozerEffect */
 const endArmdozerEffect: EndArmdozerEffect = {

--- a/test/effect/update-remaining-turn/is-remaining-armdozer-effect.test.ts
+++ b/test/effect/update-remaining-turn/is-remaining-armdozer-effect.test.ts
@@ -1,6 +1,6 @@
-import { ArmdozerEffect } from "../../../src";
 import { isRemainArmdozerEffect } from "../../../src/effect/update-remaining-turn/armdozer-effect";
 import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
 
 test("アームドーザ効果継続ターン数が1より大きい場合は効果継続する", () => {
   const data: ArmdozerEffect = {

--- a/test/effect/update-remaining-turn/update-armdozer-effect.test.ts
+++ b/test/effect/update-remaining-turn/update-armdozer-effect.test.ts
@@ -1,6 +1,6 @@
-import { ArmdozerEffect } from "../../../src";
 import { updateArmdozerEffect } from "../../../src/effect/update-remaining-turn/armdozer-effect";
 import { EMPTY_ARMDOZER_EFFECT } from "../../../src/empty/amrdozer-effect";
+import { ArmdozerEffect } from "../../../src/state/armdozer-effect";
 
 test("ターン制限付き効果なら、継続ターン数を-1する", () => {
   const data: ArmdozerEffect = {

--- a/test/effect/update-remaining-turn/update-remaining-turn-schema.test.ts
+++ b/test/effect/update-remaining-turn/update-remaining-turn-schema.test.ts
@@ -1,4 +1,4 @@
-import { UpdateRemainingTurnSchema } from "../../../src";
+import { UpdateRemainingTurnSchema } from "../../../src/effect/update-remaining-turn/update-remaining-turn";
 import { validUpdateRemainingTurn } from "./valid-update-remaining-turn";
 
 test("UpdateRemainingTurnはパースできる", () => {

--- a/test/effect/update-remaining-turn/valid-update-remaining-turn.ts
+++ b/test/effect/update-remaining-turn/valid-update-remaining-turn.ts
@@ -1,4 +1,4 @@
-import { UpdateRemainingTurn } from "../../../src";
+import { UpdateRemainingTurn } from "../../../src/effect/update-remaining-turn/update-remaining-turn";
 
 /** 有効なUpdateRemainingTurn */
 export const validUpdateRemainingTurn: UpdateRemainingTurn = {

--- a/test/game/end-judging/even-match-schema.test.ts
+++ b/test/game/end-judging/even-match-schema.test.ts
@@ -1,4 +1,7 @@
-import { EvenMatch, EvenMatchSchema } from "../../../src";
+import {
+  EvenMatch,
+  EvenMatchSchema,
+} from "../../../src/game/end-judging/game-end-judging";
 
 /** 有効なEvenMatch */
 const evenMatch: EvenMatch = {

--- a/test/game/end-judging/game-continue-schema.test.ts
+++ b/test/game/end-judging/game-continue-schema.test.ts
@@ -1,4 +1,7 @@
-import { GameContinue, GameContinueSchema } from "../../../src";
+import {
+  GameContinue,
+  GameContinueSchema,
+} from "../../../src/game/end-judging/game-end-judging";
 
 /** 有効なGameContinue */
 const gameContinue: GameContinue = {

--- a/test/game/end-judging/game-end-judging-schema.test.ts
+++ b/test/game/end-judging/game-end-judging-schema.test.ts
@@ -1,4 +1,7 @@
-import { GameEndJudging, GameEndJudgingSchema } from "../../../src/game/end-judging/game-end-judging";
+import {
+  GameEndJudging,
+  GameEndJudgingSchema,
+} from "../../../src/game/end-judging/game-end-judging";
 
 /** 有効なGameEndJudging */
 const gameEndJudges: GameEndJudging[] = [

--- a/test/game/end-judging/game-end-judging-schema.test.ts
+++ b/test/game/end-judging/game-end-judging-schema.test.ts
@@ -1,4 +1,4 @@
-import { GameEndJudging, GameEndJudgingSchema } from "../../../src";
+import { GameEndJudging, GameEndJudgingSchema } from "../../../src/game/end-judging/game-end-judging";
 
 /** 有効なGameEndJudging */
 const gameEndJudges: GameEndJudging[] = [

--- a/test/game/end-judging/game-over-schema.test.ts
+++ b/test/game/end-judging/game-over-schema.test.ts
@@ -1,4 +1,7 @@
-import { GameOver, GameOverSchema } from "../../../src";
+import {
+  GameOver,
+  GameOverSchema,
+} from "../../../src/game/end-judging/game-end-judging";
 
 /** 有効なGameOver */
 const gameOver: GameOver = {

--- a/test/game/gbraver-burst-core.test.ts
+++ b/test/game/gbraver-burst-core.test.ts
@@ -1,7 +1,8 @@
-import { PlayerCommand, RestoreGBraverBurstSchema } from "../../src";
 import { EMPTY_ARMDOZER } from "../../src/empty/armdozer";
 import { EMPTY_PILOT } from "../../src/empty/pilot";
 import { restoreGBraverBurst, startGBraverBurst } from "../../src/game";
+import { PlayerCommand } from "../../src/game/command/player-command";
+import { RestoreGBraverBurstSchema } from "../../src/game/restore-gbraver-burst";
 import { Player } from "../../src/player/player";
 
 /** プレイヤー1 */

--- a/test/game/progress/battle-flow/can-reflect-flow.test.ts
+++ b/test/game/progress/battle-flow/can-reflect-flow.test.ts
@@ -1,12 +1,10 @@
-import {
-  ArmdozerEffect,
-  ArmdozerEffectsDisabled,
-  Battle,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-} from "../../../../src";
+import { Battle } from "../../../../src/effect/battle/battle";
+import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { canReflectFlow } from "../../../../src/game/progress/battle-flow/can-reflect-flow";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
+import { ArmdozerEffectsDisabled } from "../../../../src/state/armdozer-effect/armdozer-effects-disabled";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** 防御側プレイヤー */
 const attacker: PlayerState = { ...EMPTY_PLAYER_STATE, playerId: "attacker" };

--- a/test/game/progress/battle-flow/game-continue-flow.test.ts
+++ b/test/game/progress/battle-flow/game-continue-flow.test.ts
@@ -1,12 +1,10 @@
-import {
-  ArmdozerEffect,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  GameState,
-  PlayerState,
-} from "../../../../src";
+import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { gameContinueFlow } from "../../../../src/game/progress/battle-flow/game-continue-flow";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
+import { GameState } from "../../../../src/state/game-state";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /**
  * プレイヤー1を生成する

--- a/test/game/progress/battle-flow/reflect-flow.test.ts
+++ b/test/game/progress/battle-flow/reflect-flow.test.ts
@@ -1,11 +1,9 @@
-import {
-  ArmdozerEffect,
-  EMPTY_ARMDOZER_STATE,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-} from "../../../../src";
+import { EMPTY_ARMDOZER_STATE } from "../../../../src/empty/armdozer";
+import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { reflectFlow } from "../../../../src/game/progress/battle-flow/reflect-flow";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** 攻撃側プレイヤー */
 const ATTACKER: PlayerState = {

--- a/test/game/progress/effect-activation-flow/activate-effect-or-not.test.ts
+++ b/test/game/progress/effect-activation-flow/activate-effect-or-not.test.ts
@@ -1,14 +1,12 @@
-import {
-  BatteryCommand,
-  BurstCommand,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  GameState,
-  PilotSkillCommand,
-  PlayerCommand,
-  PlayerState,
-} from "../../../../src";
+import { BatteryCommand } from "../../../../src/command/battery";
+import { BurstCommand } from "../../../../src/command/burst";
+import { PilotSkillCommand } from "../../../../src/command/pilot-skill";
+import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
+import { PlayerCommand } from "../../../../src/game/command/player-command";
 import { activateEffectOrNot } from "../../../../src/game/progress/effect-activation-flow/activate-effect-or-not";
+import { GameState } from "../../../../src/state/game-state";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** バーストコマンド */
 const BURST_COMMAND: BurstCommand = {

--- a/test/game/progress/effect-activation-flow/effect-activation-flow.test.ts
+++ b/test/game/progress/effect-activation-flow/effect-activation-flow.test.ts
@@ -1,17 +1,15 @@
-import {
-  BatteryCommand,
-  Burst,
-  BurstCommand,
-  ForceTurnEnd,
-  GameState,
-  PlayerCommand,
-  PlayerId,
-  PlayerState,
-} from "../../../../src";
+import { BatteryCommand } from "../../../../src/command/battery";
+import { BurstCommand } from "../../../../src/command/burst";
 import { PilotSkillCommand } from "../../../../src/command/pilot-skill";
 import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
+import { PlayerCommand } from "../../../../src/game/command/player-command";
 import { effectActivationFlow } from "../../../../src/game/progress/effect-activation-flow";
+import { Burst } from "../../../../src/player/burst";
+import { ForceTurnEnd } from "../../../../src/player/burst/force-turn-end";
+import { PlayerId } from "../../../../src/player/player";
+import { GameState } from "../../../../src/state/game-state";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /**
  * テストプレイヤーを生成する

--- a/test/game/progress/effect-activation-flow/post-force-turn-end-flow.test.ts
+++ b/test/game/progress/effect-activation-flow/post-force-turn-end-flow.test.ts
@@ -1,10 +1,8 @@
-import {
-  ArmdozerEffect,
-  EMPTY_GAME_STATE,
-  EMPTY_PLAYER_STATE,
-  PlayerState,
-} from "../../../../src";
+import { PlayerState } from "../../../../src";
+import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { postForceTurnEndFlow } from "../../../../src/game/progress/effect-activation-flow/post-force-turn-end-flow";
+import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
 
 /** バースト発動プレイヤーID */
 const burstPlayerId = "burstPlayer";

--- a/test/game/progress/effect-activation-flow/post-force-turn-end-flow.test.ts
+++ b/test/game/progress/effect-activation-flow/post-force-turn-end-flow.test.ts
@@ -1,8 +1,8 @@
-import { PlayerState } from "../../../../src";
 import { EMPTY_GAME_STATE } from "../../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { postForceTurnEndFlow } from "../../../../src/game/progress/effect-activation-flow/post-force-turn-end-flow";
 import { ArmdozerEffect } from "../../../../src/state/armdozer-effect";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** バースト発動プレイヤーID */
 const burstPlayerId = "burstPlayer";

--- a/test/game/progress/effect-activation-flow/sort-command-by-attacker-first.test.ts
+++ b/test/game/progress/effect-activation-flow/sort-command-by-attacker-first.test.ts
@@ -1,7 +1,7 @@
-import { PlayerState } from "../../../../src";
 import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
 import { PlayerCommand } from "../../../../src/game/command/player-command";
 import { sortCommandByAttackerFirst } from "../../../../src/game/progress/effect-activation-flow/sort-command-by-attacker-first";
+import { PlayerState } from "../../../../src/state/player-state";
 
 /** 攻撃側プレイヤー */
 const attacker: PlayerState = {

--- a/test/game/progress/effect-activation-flow/sort-command-by-attacker-first.test.ts
+++ b/test/game/progress/effect-activation-flow/sort-command-by-attacker-first.test.ts
@@ -1,8 +1,6 @@
-import {
-  EMPTY_PLAYER_STATE,
-  PlayerCommand,
-  PlayerState,
-} from "../../../../src";
+import { PlayerState } from "../../../../src";
+import { EMPTY_PLAYER_STATE } from "../../../../src/empty/player";
+import { PlayerCommand } from "../../../../src/game/command/player-command";
 import { sortCommandByAttackerFirst } from "../../../../src/game/progress/effect-activation-flow/sort-command-by-attacker-first";
 
 /** 攻撃側プレイヤー */

--- a/test/game/progress/progress.test.ts
+++ b/test/game/progress/progress.test.ts
@@ -1,14 +1,12 @@
-import {
-  BatteryCommand,
-  BurstCommand,
-  GameState,
-  PlayerCommand,
-  PlayerState,
-} from "../../../src";
+import { BatteryCommand } from "../../../src/command/battery";
+import { BurstCommand } from "../../../src/command/burst";
 import { PilotSkillCommand } from "../../../src/command/pilot-skill";
 import { EMPTY_GAME_STATE } from "../../../src/empty/game-state";
 import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
+import { PlayerCommand } from "../../../src/game/command/player-command";
 import { progress } from "../../../src/game/progress";
+import { GameState } from "../../../src/state/game-state";
+import { PlayerState } from "../../../src/state/player-state";
 
 /** 攻撃側プレイヤー */
 const attacker: PlayerState = { ...EMPTY_PLAYER_STATE, playerId: "attacker" };

--- a/test/game/start/start.test.ts
+++ b/test/game/start/start.test.ts
@@ -1,6 +1,7 @@
-import type { Player } from "../../../src";
-import { EMPTY_ARMDOZER, EMPTY_PILOT } from "../../../src";
+import { EMPTY_ARMDOZER } from "../../../src/empty/armdozer";
+import { EMPTY_PILOT } from "../../../src/empty/pilot";
 import { start } from "../../../src/game/start/start";
+import { Player } from "../../../src/player/player";
 
 const player1: Player = {
   playerId: "player1",

--- a/test/game/validation/is-all-player-entered-command.test.ts
+++ b/test/game/validation/is-all-player-entered-command.test.ts
@@ -1,10 +1,8 @@
-import {
-  BatteryCommand,
-  EMPTY_PLAYER,
-  Player,
-  PlayerCommand,
-} from "../../../src";
+import { BatteryCommand } from "../../../src/command/battery";
+import { EMPTY_PLAYER } from "../../../src/empty/player";
+import { PlayerCommand } from "../../../src/game/command/player-command";
 import { isAllPlayerEnteredCommand } from "../../../src/game/validation/is-all-player-entered-command";
+import { Player } from "../../../src/player/player";
 
 const player1 = { ...EMPTY_PLAYER, playerId: "player1" };
 const player2 = { ...EMPTY_PLAYER, playerId: "player2" };

--- a/test/game/validation/is-duplicate-players.test.ts
+++ b/test/game/validation/is-duplicate-players.test.ts
@@ -1,4 +1,4 @@
-import { EMPTY_PLAYER } from "../../../src";
+import { EMPTY_PLAYER } from "../../../src/empty/player";
 import { isDuplicatePlayers } from "../../../src/game/validation/is-duplicate-players";
 
 const player1 = { ...EMPTY_PLAYER, playerId: "player1" };

--- a/test/game/validation/is-valid-command.test.ts
+++ b/test/game/validation/is-valid-command.test.ts
@@ -1,12 +1,12 @@
+import { BatteryCommand } from "../../../src/command/battery";
+import { BurstCommand } from "../../../src/command/burst";
+import { PilotSkillCommand } from "../../../src/command/pilot-skill";
 import {
-  BatteryCommand,
-  BurstCommand,
   InputCommand,
   NoChoice,
-  PilotSkillCommand,
-  PlayerCommand,
   Selectable,
-} from "../../../src";
+} from "../../../src/effect/input-command/input-command";
+import { PlayerCommand } from "../../../src/game/command/player-command";
 import { isValidCommand } from "../../../src/game/validation/is-valid-command";
 
 /**

--- a/test/player/armdozer-id-schema.test.ts
+++ b/test/player/armdozer-id-schema.test.ts
@@ -1,4 +1,5 @@
-import { ArmdozerId, ArmdozerIds, ArmdozerIdSchema } from "../../src";
+import { ArmdozerIds } from "../../src/master/armdozers/armdozer-ids";
+import { ArmdozerId, ArmdozerIdSchema } from "../../src/player/armdozer";
 
 test("ArmDozerIdはパースできる", () => {
   const data: ArmdozerId = ArmdozerIds.SHIN_BRAVER;

--- a/test/player/armdozer-schema.test.ts
+++ b/test/player/armdozer-schema.test.ts
@@ -1,4 +1,5 @@
-import { Armdozer, ArmdozerSchema, EMPTY_ARMDOZER } from "../../src";
+import { EMPTY_ARMDOZER } from "../../src/empty/armdozer";
+import { Armdozer, ArmdozerSchema } from "../../src/player/armdozer";
 
 test("アームドーザはパースできる", () => {
   const data: Armdozer = EMPTY_ARMDOZER;

--- a/test/player/burst/battery-drain-schema.test.ts
+++ b/test/player/burst/battery-drain-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryDrain, BatteryDrainSchema } from "../../../src";
+import {
+  BatteryDrain,
+  BatteryDrainSchema,
+} from "../../../src/player/burst/battery-drain";
 
 /** 有効なBatteryLimitDrain */
 const batteryDrain: BatteryDrain = {

--- a/test/player/burst/battery-limit-break-schema.test.ts
+++ b/test/player/burst/battery-limit-break-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryLimitBreak, BatteryLimitBreakSchema } from "../../../src";
+import {
+  BatteryLimitBreak,
+  BatteryLimitBreakSchema,
+} from "../../../src/player/burst/battery-limit-break";
 
 /** 有効なBatteryLimitBreak */
 const batteryLimitBreak: BatteryLimitBreak = {

--- a/test/player/burst/buff-power-schema.test.ts
+++ b/test/player/burst/buff-power-schema.test.ts
@@ -1,4 +1,7 @@
-import { BuffPower, BuffPowerSchema } from "../../../src";
+import {
+  BuffPower,
+  BuffPowerSchema,
+} from "../../../src/player/burst/buff-power";
 
 /** 有効なBuffPower */
 const buffPower: BuffPower = {

--- a/test/player/burst/burst-schema.test.ts
+++ b/test/player/burst/burst-schema.test.ts
@@ -1,4 +1,4 @@
-import { Burst, BurstSchema } from "../../../src";
+import { Burst, BurstSchema } from "../../../src/player/burst";
 
 /** 有効なバースト */
 const bursts: Burst[] = [

--- a/test/player/burst/continuous-attack-schema.test.ts
+++ b/test/player/burst/continuous-attack-schema.test.ts
@@ -1,4 +1,7 @@
-import { ContinuousAttack, ContinuousAttackSchema } from "../../../src";
+import {
+  ContinuousAttack,
+  ContinuousAttackSchema,
+} from "../../../src/player/burst/continuous-attack";
 
 /** 有効なContinuousAttack */
 const continuousAttack: ContinuousAttack = {

--- a/test/player/burst/effect-clear-schema.test.ts
+++ b/test/player/burst/effect-clear-schema.test.ts
@@ -1,4 +1,7 @@
-import { EffectClear, EffectClearSchema } from "../../../src";
+import {
+  EffectClear,
+  EffectClearSchema,
+} from "../../../src/player/burst/effect-clear";
 
 /** EffectClear */
 const effectClear: EffectClear = {

--- a/test/player/burst/force-turn-end-schema.test.ts
+++ b/test/player/burst/force-turn-end-schema.test.ts
@@ -1,4 +1,7 @@
-import { ForceTurnEnd, ForceTurnEndSchema } from "../../../src";
+import {
+  ForceTurnEnd,
+  ForceTurnEndSchema,
+} from "../../../src/player/burst/force-turn-end";
 
 /** 有効なForceTurnEnd */
 const forceTurnEnd: ForceTurnEnd = {

--- a/test/player/burst/ineffective.test.ts
+++ b/test/player/burst/ineffective.test.ts
@@ -1,4 +1,7 @@
-import { Ineffective, IneffectiveSchema } from "../../../src";
+import {
+  Ineffective,
+  IneffectiveSchema,
+} from "../../../src/player/burst/ineffective";
 
 /** Ineffective */
 const ineffective: Ineffective = {

--- a/test/player/burst/lightning-barrier-schema.test.ts
+++ b/test/player/burst/lightning-barrier-schema.test.ts
@@ -1,4 +1,7 @@
-import { LightningBarrier, LightningBarrierSchema } from "../../../src";
+import {
+  LightningBarrier,
+  LightningBarrierSchema,
+} from "../../../src/player/burst/lightning-barrier";
 
 /** 有効なLightningBarrier */
 const lightningBarrier: LightningBarrier = {

--- a/test/player/burst/recover-battery-schema.test.ts
+++ b/test/player/burst/recover-battery-schema.test.ts
@@ -1,4 +1,7 @@
-import { RecoverBattery, RecoverBatterySchema } from "../../../src";
+import {
+  RecoverBattery,
+  RecoverBatterySchema,
+} from "../../../src/player/burst/recover-battery";
 
 /** 有効なRecoverBattery */
 const recoverBattery: RecoverBattery = {

--- a/test/player/pilot-id-schema.test.ts
+++ b/test/player/pilot-id-schema.test.ts
@@ -1,4 +1,5 @@
-import { PilotId, PilotIds, PilotIdSchema } from "../../src";
+import { PilotIds } from "../../src/master/pilots/pilot-ids";
+import { PilotId, PilotIdSchema } from "../../src/player/pilot";
 
 test("PilotIdはパースできる", () => {
   const data: PilotId = PilotIds.SHINYA;

--- a/test/player/pilot/battery-boost-skill-schema.test.ts
+++ b/test/player/pilot/battery-boost-skill-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryBoostSkill, BatteryBoostSkillSchema } from "../../../src";
+import {
+  BatteryBoostSkill,
+  BatteryBoostSkillSchema,
+} from "../../../src/player/pilot/battery-boost-skill";
 
 /** 有効なBatteryBoostSkill */
 const batteryBoostSkill: BatteryBoostSkill = {

--- a/test/player/pilot/battery-enhancement-skill-schema.test.ts
+++ b/test/player/pilot/battery-enhancement-skill-schema.test.ts
@@ -1,7 +1,7 @@
 import {
   BatteryEnhancementSkill,
   BatteryEnhancementSkillSchema,
-} from "../../../src";
+} from "../../../src/player/pilot/battery-enhancement-skill";
 
 /** 有効なBatteryEnhancementSkill */
 const batteryEnhancementSkill: BatteryEnhancementSkill = {

--- a/test/player/pilot/buff-power-skill-schema.test.ts
+++ b/test/player/pilot/buff-power-skill-schema.test.ts
@@ -1,4 +1,7 @@
-import { BuffPowerSkill, BuffPowerSkillSchema } from "../../../src";
+import {
+  BuffPowerSkill,
+  BuffPowerSkillSchema,
+} from "../../../src/player/pilot/buff-power-skill";
 
 /** 有効なBuffPowerSkill */
 const buffPowerSkill: BuffPowerSkill = {

--- a/test/player/pilot/damage-halved-skill-schema.test.ts
+++ b/test/player/pilot/damage-halved-skill-schema.test.ts
@@ -1,4 +1,7 @@
-import { DamageHalvedSkill, DamageHalvedSkillSchema } from "../../../src";
+import {
+  DamageHalvedSkill,
+  DamageHalvedSkillSchema,
+} from "../../../src/player/pilot/damage-halved-skill";
 
 /** 有効なDamageHalvedSkill */
 const damageHalvedSkill: DamageHalvedSkill = {

--- a/test/player/pilot/pilot-schema.test.ts
+++ b/test/player/pilot/pilot-schema.test.ts
@@ -1,4 +1,5 @@
-import { EMPTY_PILOT, Pilot, PilotSchema } from "../../../src";
+import { EMPTY_PILOT } from "../../../src/empty/pilot";
+import { Pilot, PilotSchema } from "../../../src/player/pilot";
 
 test("Pilotはパースできる", () => {
   const data: Pilot = EMPTY_PILOT;

--- a/test/player/pilot/pilot-skill-schema.test.ts
+++ b/test/player/pilot/pilot-skill-schema.test.ts
@@ -1,4 +1,7 @@
-import { PilotSkill, PilotSkillSchema } from "../../../src";
+import {
+  PilotSkill,
+  PilotSkillSchema,
+} from "../../../src/player/pilot/pilot-skill";
 
 /** 有効なパイロットスキル */
 const pilotSkills: PilotSkill[] = [

--- a/test/player/pilot/recover-battery-skill-schema.test.ts
+++ b/test/player/pilot/recover-battery-skill-schema.test.ts
@@ -1,4 +1,7 @@
-import { RecoverBatterySkill, RecoverBatterySkillSchema } from "../../../src";
+import {
+  RecoverBatterySkill,
+  RecoverBatterySkillSchema,
+} from "../../../src/player/pilot/recover-battery-skill";
 
 /** 有効なRecoverBatterySkill */
 const recoverBatterySkill: RecoverBatterySkill = {

--- a/test/player/player-id-schema.test.ts
+++ b/test/player/player-id-schema.test.ts
@@ -1,4 +1,4 @@
-import { PlayerId, PlayerIdSchema } from "../../src";
+import { PlayerId, PlayerIdSchema } from "../../src/player/player";
 
 test("PlyerIdはパースできる", () => {
   const data: PlayerId = "player";

--- a/test/player/player-schema.test.ts
+++ b/test/player/player-schema.test.ts
@@ -1,4 +1,5 @@
-import { EMPTY_PLAYER, Player, PlayerSchema } from "../../src";
+import { EMPTY_PLAYER } from "../../src/empty/player";
+import { Player, PlayerSchema } from "../../src/player/player";
 
 test("Playerはパースできる", () => {
   const data: Player = EMPTY_PLAYER;

--- a/test/state/armdozer-effect/armdozer-effect-schema.test.ts
+++ b/test/state/armdozer-effect/armdozer-effect-schema.test.ts
@@ -1,4 +1,7 @@
-import { ArmdozerEffect, ArmdozerEffectSchema } from "../../../src";
+import {
+  ArmdozerEffect,
+  ArmdozerEffectSchema,
+} from "../../../src/state/armdozer-effect";
 
 /** 有効なArmdozerEffect */
 const armdozerEffects: ArmdozerEffect[] = [

--- a/test/state/armdozer-effect/armdozer-effects-disabled.test.ts
+++ b/test/state/armdozer-effect/armdozer-effects-disabled.test.ts
@@ -1,7 +1,7 @@
 import {
   ArmdozerEffectsDisabled,
   ArmdozerEffectsDisabledSchema,
-} from "../../../src";
+} from "../../../src/state/armdozer-effect/armdozer-effects-disabled";
 
 /** 有効なArmdozerEffectsDisabled */
 const armdozerEffectsDisabledTest: ArmdozerEffectsDisabled = {

--- a/test/state/armdozer-effect/battery-correction-schema.test.ts
+++ b/test/state/armdozer-effect/battery-correction-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryCorrection, BatteryCorrectionSchema } from "../../../src";
+import {
+  BatteryCorrection,
+  BatteryCorrectionSchema,
+} from "../../../src/state/armdozer-effect/battery-correction";
 
 /** 有効な BatteryCorrection */
 const batteryCorrection: BatteryCorrection = {

--- a/test/state/armdozer-effect/battery-recover-skip-schema.test.ts
+++ b/test/state/armdozer-effect/battery-recover-skip-schema.test.ts
@@ -1,4 +1,7 @@
-import { BatteryRecoverSkip, BatteryRecoverSkipSchema } from "../../../src";
+import {
+  BatteryRecoverSkip,
+  BatteryRecoverSkipSchema,
+} from "../../../src/state/armdozer-effect/battery-recover-skip";
 
 /** 有効なBatteryRecoverSkip */
 const batteryRecoverSkip: BatteryRecoverSkip = {

--- a/test/state/armdozer-effect/continuous-active-player-schema.test.ts
+++ b/test/state/armdozer-effect/continuous-active-player-schema.test.ts
@@ -1,7 +1,7 @@
 import {
   ContinuousActivePlayer,
   ContinuousActivePlayerSchema,
-} from "../../../src";
+} from "../../../src/state/armdozer-effect/continuous-active-player";
 
 /** 有効な ContinuousActivePlayer */
 const continuousActivePlayer: ContinuousActivePlayer = {

--- a/test/state/armdozer-effect/correct-power-schema.test.ts
+++ b/test/state/armdozer-effect/correct-power-schema.test.ts
@@ -1,4 +1,7 @@
-import { CorrectPower, CorrectPowerSchema } from "../../../src";
+import {
+  CorrectPower,
+  CorrectPowerSchema,
+} from "../../../src/state/armdozer-effect/correct-power";
 
 /** 有効なCorrectPower */
 const correctPower: CorrectPower = {

--- a/test/state/armdozer-effect/damage-halved-schema.test.ts
+++ b/test/state/armdozer-effect/damage-halved-schema.test.ts
@@ -1,4 +1,7 @@
-import { DamageHalved, DamageHalvedSchema } from "../../../src";
+import {
+  DamageHalved,
+  DamageHalvedSchema,
+} from "../../../src/state/armdozer-effect/damage-halved";
 
 /** 有効なDamageHalved */
 const damageHalved: DamageHalved = {

--- a/test/state/armdozer-effect/effect-period-schema.test.ts
+++ b/test/state/armdozer-effect/effect-period-schema.test.ts
@@ -1,4 +1,7 @@
-import { EffectPeriod, EffectPeriodSchema } from "../../../src";
+import {
+  EffectPeriod,
+  EffectPeriodSchema,
+} from "../../../src/state/armdozer-effect/effect-period";
 
 /** 有効なEffectPeriod */
 const effectPeriods: EffectPeriod[] = [

--- a/test/state/armdozer-effect/empty-armdozer-effect-schema.test.ts
+++ b/test/state/armdozer-effect/empty-armdozer-effect-schema.test.ts
@@ -1,4 +1,7 @@
-import { EmptyArmdozerEffect, EmptyArmdozerEffectSchema } from "../../../src";
+import {
+  EmptyArmdozerEffect,
+  EmptyArmdozerEffectSchema,
+} from "../../../src/state/armdozer-effect/empty-armdozer-effect";
 
 /** 有効なEmptyArmdozerEffect */
 const emptyArmdozerEffect: EmptyArmdozerEffect = {

--- a/test/state/armdozer-effect/halve-correct-power-schema.test.ts
+++ b/test/state/armdozer-effect/halve-correct-power-schema.test.ts
@@ -1,4 +1,7 @@
-import { HalveCorrectPower, HalveCorrectPowerSchema } from "../../../src";
+import {
+  HalveCorrectPower,
+  HalveCorrectPowerSchema,
+} from "../../../src/state/armdozer-effect/halve-correct-power";
 
 /** 有効なHalveCorrectPower */
 const halveCorrectPower: HalveCorrectPower = {

--- a/test/state/armdozer-effect/reflect-damage-effect-schema.test.ts
+++ b/test/state/armdozer-effect/reflect-damage-effect-schema.test.ts
@@ -1,4 +1,7 @@
-import { ReflectDamageEffect, ReflectDamageEffectSchema } from "../../../src";
+import {
+  ReflectDamageEffect,
+  ReflectDamageEffectSchema,
+} from "../../../src/state/armdozer-effect/reflect-damage-effect";
 
 /** 有効なReflectDamageEffect */
 const reflectDamageEffect: ReflectDamageEffect = "Lightning";

--- a/test/state/armdozer-effect/special-period-effect-schema.test.ts
+++ b/test/state/armdozer-effect/special-period-effect-schema.test.ts
@@ -1,4 +1,7 @@
-import { SpecialPeriodEffect, SpecialPeriodEffectSchema } from "../../../src";
+import {
+  SpecialPeriodEffect,
+  SpecialPeriodEffectSchema,
+} from "../../../src/state/armdozer-effect/special-period-effect";
 
 /** 有効なSpecialPeriodEffect */
 const specialPeriodEffect: SpecialPeriodEffect = {

--- a/test/state/armdozer-effect/try-reflect-schema.test.ts
+++ b/test/state/armdozer-effect/try-reflect-schema.test.ts
@@ -1,4 +1,7 @@
-import { TryReflect, TryReflectSchema } from "../../../src";
+import {
+  TryReflect,
+  TryReflectSchema,
+} from "../../../src/state/armdozer-effect/try-reflect";
 
 /** 有効なTryReflect */
 const tryReflect: TryReflect = {

--- a/test/state/armdozer-effect/turn-limit-schema.test.ts
+++ b/test/state/armdozer-effect/turn-limit-schema.test.ts
@@ -1,4 +1,7 @@
-import { TurnLimitEffect, TurnLimitEffectSchema } from "../../../src";
+import {
+  TurnLimitEffect,
+  TurnLimitEffectSchema,
+} from "../../../src/state/armdozer-effect/turn-limit-effect";
 
 /** 有効なTurnLimitEffect */
 const turnLimit: TurnLimitEffect = {

--- a/test/state/armdozer-effect/turn-start-battery-correct-schema.test.ts
+++ b/test/state/armdozer-effect/turn-start-battery-correct-schema.test.ts
@@ -1,7 +1,7 @@
 import {
   TurnStartBatteryCorrect,
   TurnStartBatteryCorrectSchema,
-} from "../../../src";
+} from "../../../src/state/armdozer-effect/turn-start-battery-correction";
 
 /** 有効なTurnStartBatteryCorrect */
 const turnStartBatteryCorrect: TurnStartBatteryCorrect = {

--- a/test/state/armdozer-state/armdozer-state-schema.test.ts
+++ b/test/state/armdozer-state/armdozer-state-schema.test.ts
@@ -1,8 +1,8 @@
+import { EMPTY_ARMDOZER_STATE } from "../../../src/empty/armdozer";
 import {
   ArmdozerState,
   ArmdozerStateSchema,
-  EMPTY_ARMDOZER_STATE,
-} from "../../../src";
+} from "../../../src/state/armdozer-state";
 
 /** 有効なArmdozerState */
 const armdozerState: ArmdozerState = EMPTY_ARMDOZER_STATE;

--- a/test/state/armdozer-state/create-armdozer-state.test.ts
+++ b/test/state/armdozer-state/create-armdozer-state.test.ts
@@ -1,4 +1,5 @@
-import { Armdozer, EMPTY_ARMDOZER } from "../../../src";
+import { EMPTY_ARMDOZER } from "../../../src/empty/armdozer";
+import { Armdozer } from "../../../src/player/armdozer";
 import { createArmdozerState } from "../../../src/state/armdozer-state/create-armdozer-state";
 
 test("追加されたパラメータに正しい値がセットされている", () => {

--- a/test/state/game-state-schema.test.ts
+++ b/test/state/game-state-schema.test.ts
@@ -1,4 +1,5 @@
-import { EMPTY_GAME_STATE, GameStateSchema } from "../../src";
+import { EMPTY_GAME_STATE } from "../../src/empty/game-state";
+import { GameStateSchema } from "../../src/state/game-state";
 
 test("GameStateはパースできる", () => {
   expect(GameStateSchema.parse(EMPTY_GAME_STATE)).toEqual(EMPTY_GAME_STATE);

--- a/test/state/pilot-state/create-pilot-state.test.ts
+++ b/test/state/pilot-state/create-pilot-state.test.ts
@@ -1,4 +1,6 @@
-import { EMPTY_PILOT, Pilot, PilotState } from "../../../src";
+import { EMPTY_PILOT } from "../../../src/empty/pilot";
+import { Pilot } from "../../../src/player/pilot";
+import { PilotState } from "../../../src/state/pilot-state";
 import { createPilotState } from "../../../src/state/pilot-state/create-pilot-state";
 
 test("パイロットステート生成処理を正しく処理できる", () => {

--- a/test/state/pilot-state/pilot-state-schema.test.ts
+++ b/test/state/pilot-state/pilot-state-schema.test.ts
@@ -1,4 +1,5 @@
-import { EMPTY_PILOT_STATE, PilotState, PilotStateSchema } from "../../../src";
+import { EMPTY_PILOT_STATE } from "../../../src/empty/pilot";
+import { PilotState, PilotStateSchema } from "../../../src/state/pilot-state";
 
 /** 有効なPilotState */
 const pilotState: PilotState = EMPTY_PILOT_STATE;

--- a/test/state/player-state/player-state-schema.test.ts
+++ b/test/state/player-state/player-state-schema.test.ts
@@ -1,8 +1,8 @@
+import { EMPTY_PLAYER_STATE } from "../../../src/empty/player";
 import {
-  EMPTY_PLAYER_STATE,
   PlayerState,
   PlayerStateSchema,
-} from "../../../src";
+} from "../../../src/state/player-state";
 
 /** 有効なPlayerState */
 const playerState: PlayerState = EMPTY_PLAYER_STATE;


### PR DESCRIPTION
This pull request introduces a series of changes to improve code organization by restructuring import paths and enforcing new dependency rules. The most significant updates include adding a new rule to prevent improper imports from `src/index.ts` and reorganizing test file imports to align with a more modular directory structure.

### Dependency Rule Updates:
* [`.dependency-cruiser.mjs`](diffhunk://#diff-80c996ece191d68ef7bfaff56ab568076ccc51e26877c3076b6f11411d14eb1eR5-R12): Added a new rule named `no-import-src-index` to prevent importing `src/index.ts` from product or test code, ensuring it is reserved for npm consumers.

### Test File Import Reorganization:
* [`test/command/*.test.ts`](diffhunk://#diff-d293aa2afedcbc9f9ccb2a80c8ff3c63693d62e9d75d511eb33ccd4eea126369L1-R4): Updated import paths for command-related schemas (`BatteryCommandSchema`, `BurstCommandSchema`, `CommandSchema`, `PilotSkillCommandSchema`) to reflect their new locations under `src/command`. [[1]](diffhunk://#diff-d293aa2afedcbc9f9ccb2a80c8ff3c63693d62e9d75d511eb33ccd4eea126369L1-R4) [[2]](diffhunk://#diff-a21801bfe0315d6a511804d5f02508a549743ffc42937841aa0a88bf15740862L1-R1) [[3]](diffhunk://#diff-a65d39c90cb607185aadc07869443f2c81ac12ec1c4a2ce57e6200bc8d80735dL1-R1) [[4]](diffhunk://#diff-5a21ec4a8b57e61f6e8aae1e6b74c112947c4d26f8c7f8dc78f67a9cb1fa6167L1-R4)
* [`test/effect/battery-declaration/*.test.ts`](diffhunk://#diff-8583bd843cca365906cf97230d0eb673c737589774d29acb12c4e9595ffb79a4L1-R1): Adjusted import paths for `BatteryDeclarationSchema` and related entities to their new location under `src/effect/battery-declaration`. [[1]](diffhunk://#diff-8583bd843cca365906cf97230d0eb673c737589774d29acb12c4e9595ffb79a4L1-R1) [[2]](diffhunk://#diff-49e3910e18012909544913be6a372d60429cdf7dc690654a8573d690c231c6eaL1-R8) [[3]](diffhunk://#diff-1793124b05d14616c0c859ca8bc2b2566f68df9d3a4e50d54cd6fb560cfd7784L1-R1)
* [`test/effect/battle/*.test.ts`](diffhunk://#diff-fca29662d5ebef5998c281d5b72e3e3694ed867533f0a6fdc51329fc93dfd622L1-R1): Updated import paths for `BattleSchema`, `BattleResultSchema`, and related entities to their new location under `src/effect/battle`. [[1]](diffhunk://#diff-fca29662d5ebef5998c281d5b72e3e3694ed867533f0a6fdc51329fc93dfd622L1-R1) [[2]](diffhunk://#diff-bc4aae591952ec8cf878704c99449bb2fdc591d57503bc9563d826dea58a998bL1-R4) [[3]](diffhunk://#diff-2fc7fd354aba922841916c1f9c1c9029da14d8d9401f8cf93b6166efc3139162L1-R4) [[4]](diffhunk://#diff-1b57c4b6d78735c535686ef21fa9e7ae4b2d8f2b907ff86c2545bc73864a21ccL1-R1) [[5]](diffhunk://#diff-910b8d516b6f6f8b8e9a539f487d2dd91b1db4929b1a806fcb7c9d9029aec738L1-R1) [[6]](diffhunk://#diff-1d086348441c5d484d28f3e01cfa43cfbf9f87f1450b19e0565ba962cd1741d4L1-R1) [[7]](diffhunk://#diff-0f7895c53b4e9872b41d581583aa933b637f5d882d8b953489932cea3bd54f06L1-R4) [[8]](diffhunk://#diff-929ae640c4a26c03065d10a6b6d9994591c1962f5d88624f6571ca91295a6f34L1-R1)
* [`test/effect/burst/*.test.ts`](diffhunk://#diff-a953140258431186d8167cd82643a02b0ae19c55566f05e5309a13291d1de4adL1-R6): Adjusted import paths for `GameState`, `PlayerState`, and other entities to reflect their new modular structure under `src/state` and `src/effect/burst`. [[1]](diffhunk://#diff-a953140258431186d8167cd82643a02b0ae19c55566f05e5309a13291d1de4adL1-R6) [[2]](diffhunk://#diff-8b5575140b5676d02d596a364e6be9e7487f6860c5d1aab4664fba8c03218c3cL1-R6)