### PR TITLE
SonarQube CloudのIssueを修正

### DIFF
--- a/src/effect/update-remaining-turn/index.ts
+++ b/src/effect/update-remaining-turn/index.ts
@@ -36,7 +36,7 @@ export function updateRemainingTurn(
           effect: effect,
         })),
     )
-    .reduce((a, b) => a.concat(b));
+    .reduce((a, b) => a.concat(b), []);
   return {
     ...lastState,
     players: updatePlayers,

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,6 +1,6 @@
-import type { Player } from "../player/player";
-import type { GameState } from "../state/game-state";
-import type { PlayerCommand } from "./command/player-command";
+import { Player } from "../player/player";
+import { GameState } from "../state/game-state";
+import { PlayerCommand } from "./command/player-command";
 import { progress } from "./progress";
 import { RestoreGBraverBurst } from "./restore-gbraver-burst";
 import { start } from "./start/start";
@@ -38,7 +38,9 @@ export interface GBraverBurstCore {
 
 /** Gブレイバーバーストコア実装 */
 class GBraverBurstCoreImpl implements GBraverBurstCore {
-  #players: [Player, Player];
+  /** バトルに参加している全プレイヤー */
+  readonly #players: [Player, Player];
+  /** ゲームステートヒストリー */
   #stateHistory: GameState[];
 
   /**


### PR DESCRIPTION
This pull request includes changes to improve code clarity and functionality in the `src/effect/update-remaining-turn/index.ts` and `src/game/index.ts` files. The most important changes include fixing a `.reduce()` method to include an initial value, updating import statements for consistency, and adding documentation comments to clarify the purpose of private fields in the `GBraverBurstCoreImpl` class.

### Code functionality improvements:
* [`src/effect/update-remaining-turn/index.ts`](diffhunk://#diff-005992896891b21bedf0745b0cceda1adb91a6a6da0ec092673792f1c571c3e0L39-R39): Fixed the `.reduce()` method by adding an initial value (`[]`) to prevent potential errors when concatenating arrays.

### Code clarity enhancements:
* [`src/game/index.ts`](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2L1-R3): Changed `import type` statements to regular `import` statements for `Player`, `GameState`, and `PlayerCommand` to ensure consistent import usage.
* [`src/game/index.ts`](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2L41-R43): Added documentation comments to the `#players` and `#stateHistory` private fields in the `GBraverBurstCoreImpl` class to clarify their purpose.