### PR TITLE
zodをpeerDependenciesにした

### DIFF
--- a/.dependency-cruiser.mjs
+++ b/.dependency-cruiser.mjs
@@ -123,6 +123,7 @@ export default {
         // _and_ (e.g.) a devDependency - don't consider type-only dependency
         // types for this rule
         dependencyTypesNot: ["type-only"],
+        pathNot: ["node_modules/zod/"],
       },
     },
 
@@ -172,7 +173,7 @@ export default {
         // type only dependencies are not a problem as they don't end up in the
         // production code or are ignored by the runtime.
         dependencyTypesNot: ["type-only"],
-        pathNot: ["node_modules/@types/"],
+        pathNot: ["node_modules/@types/", "node_modules/zod/"],
       },
     },
     {
@@ -199,6 +200,7 @@ export default {
       from: {},
       to: {
         dependencyTypes: ["npm-peer"],
+        pathNot: ["node_modules/zod/"],
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.39.2",
       "license": "MIT",
       "dependencies": {
-        "ramda": "^0.31.3",
-        "zod": "^4.0.14"
+        "ramda": "^0.31.3"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -26,10 +25,14 @@
         "rimraf": "^6.0.1",
         "ts-jest": "^29.4.1",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.38.0"
+        "typescript-eslint": "^8.38.0",
+        "zod": "^4.0.14"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.14"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8036,6 +8039,7 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.14.tgz",
       "integrity": "sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "ramda": "^0.31.3",
-    "zod": "^4.0.14"
+    "ramda": "^0.31.3"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
@@ -25,10 +24,14 @@
     "rimraf": "^6.0.1",
     "ts-jest": "^29.4.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.38.0"
+    "typescript-eslint": "^8.38.0",
+    "zod": "^4.0.14"
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "peerDependencies": {
+    "zod": "^4.0.14"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
This pull request updates the `package.json` file to adjust the dependencies and improve package management. The most important changes include moving `zod` from `dependencies` to `peerDependencies` and ensuring it is also listed under `devDependencies`.

### Dependency adjustments:

* Removed `zod` from the `dependencies` section. (`package.json` - [package.jsonL11-R11](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11))
* Added `zod` to the `peerDependencies` section to indicate it should be provided by the consuming application. (`package.json` - [package.jsonL28-R35](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R35))
* Added `zod` to the `devDependencies` section to ensure it is available for development and testing purposes. (`package.json` - [package.jsonL28-R35](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R35))