### PR TITLE
バージョンを1.39.2から1.40.0に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.39.2",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.39.2",
+      "version": "1.40.0",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.31.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.39.2",
+  "version": "1.40.0",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",


### PR DESCRIPTION
This pull request updates the version of the `gbraver-burst-core` package to reflect new changes.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Incremented the version from `1.39.2` to `1.40.0` to signify a new release.