### PR TITLE
1.43.1のマージに失敗したのでやりなおし

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,6 +16,18 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm publish --provenance --access public
+      # semver-ベータ（例: 1.43.0-beta.1）のフォーマットをベータ版とみなす
+      # ベータ版の場合は beta タグで publish
+      # 正式版の場合は latest タグ（デフォルト）で publish
+      - name: Publish to npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-"* ]]; then
+            echo "Publishing prerelease version: $VERSION with tag beta"
+            npm publish --provenance --access public --tag beta
+          else
+            echo "Publishing stable version: $VERSION"
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ jobs:
       # ベータ版の場合は beta タグで publish
       # 正式版の場合は latest タグ（デフォルト）で publish
       - name: Publish to npm
+        shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if [[ "$VERSION" == *"-"* ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.43.0-beta.1",
+  "version": "1.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.43.0-beta.1",
+      "version": "1.43.1",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.43.0",
+  "version": "1.43.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.43.0",
+      "version": "1.43.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.43.0-beta.1",
+  "version": "1.43.1",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.43.0",
+  "version": "1.43.0-beta.1",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",


### PR DESCRIPTION
This pull request updates the npm publishing workflow to better handle prerelease (beta) and stable releases, and bumps the package version. The most significant change is the automation of npm tag assignment based on the version format.

Workflow improvements:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L19-R32): Updated the publish step to automatically detect prerelease versions (e.g., versions containing a hyphen like `1.43.0-beta.1`) and publish them with the `beta` tag, while stable releases are published with the default `latest` tag. This helps ensure prereleases do not overwrite the latest stable version on npm.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Bumped the package version from `1.43.0` to `1.43.1`.