### PR TITLE
eslintの非推奨設定の対応

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ["node_modules/*", "lib/*", "coverage/*"],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
This pull request updates the way ESLint configuration is defined by switching to the recommended `defineConfig` helper from the `eslint/config` package. This change helps ensure better type safety and future compatibility.

ESLint configuration update:

* Switched from using `tseslint.config` to the more standard `defineConfig` from `eslint/config` in `eslint.config.mjs` for defining the ESLint configuration.