### PR TITLE
npm publishまわりを修正

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,15 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+      # semver-ベータ（例: 1.43.0-beta.1）のフォーマットをベータ版とみなす
+      # ベータ版の場合は beta タグで publish
+      # 正式版の場合は latest タグ（デフォルト）で publish
       - name: Publish to npm
         shell: bash
         run: |
-          npm publish --access public
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-"* ]]; then
+            npm publish --provenance --tag beta
+          else
+            npm publish --provenance
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,19 +16,7 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      # semver-ベータ（例: 1.43.0-beta.1）のフォーマットをベータ版とみなす
-      # ベータ版の場合は beta タグで publish
-      # 正式版の場合は latest タグ（デフォルト）で publish
       - name: Publish to npm
         shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" == *"-"* ]]; then
-            echo "Publishing prerelease version: $VERSION with tag beta"
-            npm publish --provenance --access public --tag beta
-          else
-            echo "Publishing stable version: $VERSION"
-            npm publish --provenance --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --access public

--- a/Readme.md
+++ b/Readme.md
@@ -38,18 +38,6 @@ npm audit --omit=dev
 fixpack
 ```
 
-## GitHub Actions設定
-
-### Secrets設定
-
-[ここ](https://docs.github.com/ja/actions/security-guides/using-secrets-in-github-actions)を参考にGitHub ActionsのSecretsを設定する。
-以下が設定内容である。
-
-**secrets**
-| シークレット名 | 値 |
-|-------|----|
-| NPM_TOKEN | npmの[Personal Access Token](https://docs.npmjs.com/creating-and-viewing-access-tokens) |
-
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.45.0-beta.0",
+  "version": "1.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.45.0-beta.0",
+      "version": "1.45.0",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gbraver-burst-core",
-  "version": "1.44.0",
+  "version": "1.45.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gbraver-burst-core",
-      "version": "1.44.0",
+      "version": "1.45.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.45.0-beta.0",
+  "version": "1.45.0",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbraver-burst-core",
   "description": "braver burst core",
-  "version": "1.44.0",
+  "version": "1.45.0-beta.0",
   "author": "y.takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-core/issues",


### PR DESCRIPTION
This pull request contains a new release for the package, updates the publish workflow, and removes documentation about secret configuration. The most important changes are summarized below.

**Release version update:**

* Bumped the package version from `1.44.0` to `1.45.0` in `package.json` to prepare for a new release.

**CI/CD workflow changes:**

* In `.github/workflows/npm-publish.yml`, removed the explicit `--access public` flag from `npm publish` commands and eliminated the `NODE_AUTH_TOKEN` environment variable from the publish step.

**Documentation cleanup:**

* Removed the section in `Readme.md` that described setting up GitHub Actions secrets, including the usage of `NPM_TOKEN`.